### PR TITLE
fix: 登録フォームで入力時にフォーカスが外れる問題を修正

### DIFF
--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -97,7 +97,7 @@ function RegisterForm() {
     }
   };
 
-  const CommonFields = () => (
+  const commonFields = (
     <>
       <div className="space-y-2">
         <label className="text-sm font-medium">メールアドレス</label>
@@ -159,7 +159,7 @@ function RegisterForm() {
             </TabsList>
 
             <TabsContent value="user" className="space-y-4 mt-4">
-              <CommonFields />
+              {commonFields}
               <Button
                 onClick={() => handleRegister("USER")}
                 className="w-full"
@@ -174,7 +174,7 @@ function RegisterForm() {
             </TabsContent>
 
             <TabsContent value="recruiter" className="space-y-4 mt-4">
-              <CommonFields />
+              {commonFields}
               <div className="space-y-2">
                 <label className="text-sm font-medium">会社名</label>
                 <Input


### PR DESCRIPTION
## Summary
- 登録フォームの共通フィールド(`CommonFields`)がコンポーネント関数として`RegisterForm`内部に定義されていたため、state更新のたびに再マウントが発生しフォーカスが外れていた
- コンポーネント関数(`const CommonFields = () => ...`)をJSX変数(`const commonFields = ...`)に変更し、再マウントを防止

## Test plan
- [ ] 登録フォームの各入力フィールドに連続入力してフォーカスが外れないことを確認
- [ ] 求職者タブ・採用担当者タブの両方で入力が正常に動作することを確認
- [ ] タブ切り替え後も入力が正常に動作することを確認