### PR TITLE
fix: Document解析カラムのマイグレーション追加

### DIFF
--- a/prisma/migrations/20260211120000_add_document_analysis_fields/migration.sql
+++ b/prisma/migrations/20260211120000_add_document_analysis_fields/migration.sql
@@ -1,0 +1,8 @@
+-- CreateEnum
+CREATE TYPE "AnalysisStatus" AS ENUM ('PENDING', 'ANALYZING', 'COMPLETED', 'FAILED');
+
+-- AlterTable
+ALTER TABLE "Document"
+  ADD COLUMN "analysisStatus" "AnalysisStatus" NOT NULL DEFAULT 'PENDING',
+  ADD COLUMN "analysisError" TEXT,
+  ADD COLUMN "analyzedAt" TIMESTAMP(3);


### PR DESCRIPTION
## Summary
- `AnalysisStatus` enum と `Document` テーブルの `analysisStatus`, `analysisError`, `analyzedAt` カラムのマイグレーションファイルが欠落していたため追加
- Prismaスキーマには定義済みだがマイグレーションが存在せず、staging DBで全ての `/api/documents` リクエストが500エラーになっていた

## Test plan
- [ ] developにマージ後、staging環境でデプロイが成功することを確認
- [ ] `/api/documents` GET/POSTが正常に動作することを確認
- [ ] ドキュメントのアップロード・解析フローが動作することを確認