### PR TITLE
fix: ECSタスク定義にLambda関連secrets反映

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -131,7 +131,12 @@ jobs:
           ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
           IMAGE_TAG: ${{ github.sha }}
           ECS_SERVICE: ${{ vars.ECS_SERVICE }}
+          SSM_PREFIX: /metalk/${{ env.ENVIRONMENT }}
         run: |
+          if [ -z "$SSM_PREFIX" ]; then
+            echo "Error: SSM_PREFIX is not set"
+            exit 1
+          fi
           TASK_DEF_ARN=$(aws ecs describe-services \
             --cluster $ECS_CLUSTER \
             --services $ECS_SERVICE \
@@ -139,9 +144,25 @@ jobs:
           TASK_DEF=$(aws ecs describe-task-definition \
             --task-definition $TASK_DEF_ARN \
             --query 'taskDefinition' --output json)
+          REQUIRED_SECRETS='[
+            {"name":"DATABASE_URL","valueFrom":"'"$SSM_PREFIX"'/database-url"},
+            {"name":"NEXTAUTH_SECRET","valueFrom":"'"$SSM_PREFIX"'/nextauth-secret"},
+            {"name":"NEXTAUTH_URL","valueFrom":"'"$SSM_PREFIX"'/nextauth-url"},
+            {"name":"STORAGE_PROVIDER","valueFrom":"'"$SSM_PREFIX"'/storage-provider"},
+            {"name":"MINIO_ACCESS_KEY","valueFrom":"'"$SSM_PREFIX"'/minio-access-key"},
+            {"name":"MINIO_SECRET_KEY","valueFrom":"'"$SSM_PREFIX"'/minio-secret-key"},
+            {"name":"MINIO_BUCKET_NAME","valueFrom":"'"$SSM_PREFIX"'/minio-bucket-name"},
+            {"name":"AWS_REGION","valueFrom":"'"$SSM_PREFIX"'/aws-region"},
+            {"name":"OPENAI_API_KEY","valueFrom":"'"$SSM_PREFIX"'/openai-api-key"},
+            {"name":"STRIPE_SECRET_KEY","valueFrom":"'"$SSM_PREFIX"'/stripe-secret-key"},
+            {"name":"DOCUMENT_ANALYSIS_LAMBDA_ARN","valueFrom":"'"$SSM_PREFIX"'/document-analysis-lambda-arn"},
+            {"name":"ANALYSIS_CALLBACK_SECRET","valueFrom":"'"$SSM_PREFIX"'/analysis-callback-secret"}
+          ]'
           NEW_TASK_DEF=$(echo "$TASK_DEF" | jq \
             --arg IMAGE "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" \
+            --argjson SECRETS "$REQUIRED_SECRETS" \
             '.containerDefinitions[0].image = $IMAGE |
+             .containerDefinitions[0].secrets = $SECRETS |
              del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)')
           NEW_ARN=$(aws ecs register-task-definition \
             --cli-input-json "$NEW_TASK_DEF" \


### PR DESCRIPTION
## Summary
- CI/CDのタスク定義更新時にsecretsリストを明示的に上書きし、Terraformとの同期漏れを防止
- `DOCUMENT_ANALYSIS_LAMBDA_ARN` 未設定時に明示的なエラーを返すバリデーション追加
- `SSM_PREFIX` 未設定時のガード追加

## Root Cause
ECSタスク定義(revision 16)に `DOCUMENT_ANALYSIS_LAMBDA_ARN` と `ANALYSIS_CALLBACK_SECRET` が含まれていなかった。Terraform側の `lifecycle { ignore_changes = [task_definition] }` とCI/CDのイメージのみ差し替えロジックにより、新しいsecretsが反映されなかった。

## Test plan
- [ ] developへマージ後、GitHub Actionsのデプロイが成功することを確認
- [ ] staging環境で「解析する」ボタンが正常に動作することを確認