### PR TITLE
fix: GitHub ActionsロールにSSM/Lambda権限追加

### DIFF
--- a/terraform/modules/iam/github-oidc.tf
+++ b/terraform/modules/iam/github-oidc.tf
@@ -85,11 +85,22 @@ data "aws_iam_policy_document" "github_actions" {
       sid = "LambdaUpdate"
       actions = [
         "lambda:UpdateFunctionCode",
+        "lambda:UpdateFunctionConfiguration",
         "lambda:GetFunction",
         "lambda:GetFunctionConfiguration",
       ]
       resources = [var.lambda_function_arn]
     }
+  }
+
+  statement {
+    sid = "SSMGetParameter"
+    actions = [
+      "ssm:GetParameter",
+    ]
+    resources = [
+      "arn:aws:ssm:ap-northeast-1:${local.account_id}:parameter${var.ssm_parameter_prefix}/*",
+    ]
   }
 
   statement {


### PR DESCRIPTION
## Summary
- GitHub Actions IAMロールに `ssm:GetParameter` 権限を追加（`/metalk/*` スコープ）
- `lambda:UpdateFunctionConfiguration` 権限を追加（Lambda環境変数更新用）
- IAMポリシーはAWS CLIで即時適用済み。本PRはTerraformコードの同期。

## Root Cause
デプロイ時にSSMからOpenAI APIキーを取得してLambda環境変数に反映するステップで、GitHub ActionsロールにSSM読み取り権限がなかったためAccessDeniedExceptionが発生。

## Test plan
- [ ] developへマージ後、デプロイが成功することを確認