### PR TITLE
fix: prisma generateのDATABASE_URL未設定によるCI失敗を修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,8 @@ jobs:
         run: npm ci
       - if: steps.deps-cache.outputs.cache-hit != 'true'
         run: npx prisma generate
+        env:
+          DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
 
   # ============================================================================
   # Lint: biome lint + tsc 型チェック（testと並列）


### PR DESCRIPTION
## Summary
- Prisma 6では`prisma generate`実行時にも`DATABASE_URL`環境変数が必要
- installジョブの`prisma generate`ステップにダミーURLをステップレベルenvで追加
- `prisma generate`はクライアントコード生成のみでDB接続しないためダミー値で問題なし

## Test plan
- [ ] CIパイプラインが正常に通ることを確認