### PR TITLE
fix: Dockerイメージのprovenance無効化とLambdaデプロイ順序修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,6 +118,7 @@ jobs:
         with:
           context: .
           push: true
+          provenance: false
           tags: |
             ${{ steps.ecr.outputs.registry }}/${{ vars.ECR_REPOSITORY }}:${{ github.sha }}
             ${{ steps.ecr.outputs.registry }}/${{ vars.ECR_REPOSITORY }}:${{ env.ENVIRONMENT }}-latest
@@ -150,6 +151,7 @@ jobs:
           context: .
           file: lambda/document-analysis/Dockerfile
           push: true
+          provenance: false
           tags: |
             ${{ steps.ecr.outputs.registry }}/${{ vars.LAMBDA_ECR_REPOSITORY }}:${{ github.sha }}
             ${{ steps.ecr.outputs.registry }}/${{ vars.LAMBDA_ECR_REPOSITORY }}:latest
@@ -160,7 +162,7 @@ jobs:
   # Update Lambda: 関数コード更新 + 環境変数同期
   # ============================================================================
   update-lambda:
-    needs: build-lambda
+    needs: [build-lambda, migrate-db]
     runs-on: ubuntu-latest
     if: (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main') && vars.LAMBDA_FUNCTION_NAME != ''
     env:


### PR DESCRIPTION
## Summary
- `build-app`, `build-lambda`の`docker/build-push-action`に`provenance: false`を追加し、OCI形式マニフェストによるLambdaデプロイ失敗を修正
- `update-lambda`の依存関係に`migrate-db`を追加し、DBマイグレーション完了後にLambda更新が実行される順序を保証

## Test plan
- [ ] developへマージ後、`update-lambda`ジョブが正常に完了することを確認
- [ ] `deploy-ecs`ジョブも引き続き正常に動作することを確認