### PR TITLE
fix: 音声入力後にAI応答待ちのまま固まる問題を修正

### DIFF
--- a/src/components/agent/AgentBusinessCard.tsx
+++ b/src/components/agent/AgentBusinessCard.tsx
@@ -48,12 +48,7 @@ export function AgentBusinessCard({
           </p>
         </div>
         <Avatar className="size-12 ring-2 ring-border">
-          {avatarSrc && (
-            <AvatarImage
-              src={avatarSrc}
-              alt={name}
-            />
-          )}
+          {avatarSrc && <AvatarImage src={avatarSrc} alt={name} />}
           <AvatarFallback className="bg-primary/10 text-primary font-semibold">
             {name[0] || "?"}
           </AvatarFallback>


### PR DESCRIPTION
## Summary
- 音声入力後に「AI応答を待っています...」のまま固まるバグを修正
- SSEストリーミング時に `messages.length` の変化で応答完了を検知できない問題が原因
- `isLoading` の `true→false` 遷移のみで判定するよう `useVoiceConversation` を修正

## 原因
求職者チャットページはSSEストリーミングを使用しており、空のassistantメッセージが先に配列に追加されコンテンツが後から更新される。そのため `messages.length > prevLen` チェックがストリーミング完了時に `false` となり、TTS再生がトリガーされなかった。

## Test plan
- [ ] 求職者チャットページで音声入力後、AI応答が返りTTS再生に遷移すること
- [ ] recruiter面接ページでも音声入力が正常に動作すること
- [ ] push-to-talk / 連続会話の両モードで確認
- [ ] テキスト入力が従来通り動作すること