### PR TITLE
fix: ステージングで認証メールが送信されない問題を修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -296,7 +296,9 @@ jobs:
             {"name":"DOCUMENT_ANALYSIS_LAMBDA_ARN","valueFrom":"'"$SSM_PREFIX"'/document-analysis-lambda-arn"},
             {"name":"ANALYSIS_CALLBACK_SECRET","valueFrom":"'"$SSM_PREFIX"'/analysis-callback-secret"},
             {"name":"WEBAUTHN_RP_ID","valueFrom":"'"$SSM_PREFIX"'/webauthn-rp-id"},
-            {"name":"WEBAUTHN_ORIGIN","valueFrom":"'"$SSM_PREFIX"'/webauthn-origin"}
+            {"name":"WEBAUTHN_ORIGIN","valueFrom":"'"$SSM_PREFIX"'/webauthn-origin"},
+            {"name":"RESEND_API_KEY","valueFrom":"'"$SSM_PREFIX"'/resend-api-key"},
+            {"name":"EMAIL_FROM","valueFrom":"'"$SSM_PREFIX"'/email-from"}
           ]'
           NEW_TASK_DEF=$(echo "$TASK_DEF" | jq \
             --arg IMAGE "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" \

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -12,7 +12,10 @@ export async function sendVerificationEmail(
   to: string,
   token: string,
 ): Promise<void> {
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3001";
+  const appUrl =
+    process.env.NEXT_PUBLIC_APP_URL ||
+    process.env.NEXTAUTH_URL ||
+    "http://localhost:3001";
   const verifyUrl = `${appUrl}/verify-email?token=${token}`;
 
   // 開発環境: APIキーが未設定またはプレースホルダーの場合はコンソール出力のみ


### PR DESCRIPTION
## Summary
- deploy.ymlの`REQUIRED_SECRETS`に`RESEND_API_KEY`と`EMAIL_FROM`が含まれておらず、デプロイ時にsecretsが上書きされて消えていたため、ステージングのECSコンテナにResend APIキーが存在せず、メール送信がdev mode（コンソール出力のみ）にフォールバックしていた
- 認証リンクURLの生成で`NEXT_PUBLIC_APP_URL`がECSに未設定のため`http://localhost:3001`になる問題を、`NEXTAUTH_URL`へのフォールバックで修正

## 変更内容
- `.github/workflows/deploy.yml`: `REQUIRED_SECRETS`に`RESEND_API_KEY`と`EMAIL_FROM`を追加
- `src/lib/email.ts`: 認証リンクURL生成のフォールバックに`NEXTAUTH_URL`を追加

## 調査経緯
1. ECSログで `The column Account.emailVerified does not exist in the current database.` を確認 → 最新デプロイでマイグレーション適用済み
2. 現在のECSタスク定義（rev 52）のsecretsに`RESEND_API_KEY`/`EMAIL_FROM`が存在しないことを確認
3. deploy.ymlの`REQUIRED_SECRETS`でsecretsが全上書きされ、この2つが漏れていたことが根本原因

## Test plan
- [ ] developにマージ後、ステージング環境で新規ユーザー登録を行い、認証メールが届くことを確認
- [ ] 認証メールのリンクURLが `https://metalk-staging.raim-tech.com/verify-email?token=...` になっていることを確認
- [ ] リンクをクリックしてメール認証が完了することを確認