### PR TITLE
feat: 新規登録時の自動ログインとメール認証後のシームレス遷移

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -68,6 +68,7 @@ export async function middleware(request: NextRequest) {
   }
 
   // メール未認証ユーザーの制限
+  // /check-email, /verify-email は publicRoutes で処理済みのためここには到達しない
   if (!token.emailVerified) {
     if (isApiRoute) {
       return NextResponse.json(
@@ -75,14 +76,7 @@ export async function middleware(request: NextRequest) {
         { status: 403 },
       );
     }
-    const emailVerificationAllowedRoutes = ["/check-email", "/verify-email"];
-    const isAllowed = emailVerificationAllowedRoutes.some(
-      (route) => pathname === route || pathname.startsWith(`${route}/`),
-    );
-    if (!isAllowed) {
-      return NextResponse.redirect(new URL("/check-email", request.url));
-    }
-    return NextResponse.next();
+    return NextResponse.redirect(new URL("/check-email", request.url));
   }
 
   // 2FA不要で /verify-passkey にアクセスした場合はダッシュボードへ

--- a/middleware.ts
+++ b/middleware.ts
@@ -16,24 +16,35 @@ const passkeyVerificationAllowedRoutes = ["/verify-passkey"];
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
-  // 公開ルート・APIルート・静的ファイルはスキップ
+  // 公開ルート・静的ファイルはスキップ
   if (
     publicRoutes.some(
       (route) =>
         pathname === route ||
         (route !== "/" && pathname.startsWith(`${route}/`)),
     ) ||
-    pathname.startsWith("/api/") ||
     pathname.startsWith("/_next/") ||
     /\.\w+$/.test(pathname)
   ) {
     return NextResponse.next();
   }
 
+  // 認証系APIは公開
+  if (
+    pathname.startsWith("/api/auth/") ||
+    pathname.startsWith("/api/webhooks/")
+  ) {
+    return NextResponse.next();
+  }
+
+  const isApiRoute = pathname.startsWith("/api/");
   const token = await getToken({ req: request });
 
-  // 未認証 → ログインへ（元URLを保持）
+  // 未認証 → ログインへ（元URLを保持）/ APIは401
   if (!token) {
+    if (isApiRoute) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
     const loginUrl = new URL("/login", request.url);
     loginUrl.searchParams.set("callbackUrl", pathname);
     return NextResponse.redirect(loginUrl);
@@ -41,11 +52,35 @@ export async function middleware(request: NextRequest) {
 
   // パスキー2FA検証が必要な場合
   if (token.passkeyVerificationRequired) {
+    if (isApiRoute) {
+      return NextResponse.json(
+        { error: "2FA verification required" },
+        { status: 403 },
+      );
+    }
     const isAllowed = passkeyVerificationAllowedRoutes.some(
       (route) => pathname === route || pathname.startsWith(`${route}/`),
     );
     if (!isAllowed) {
       return NextResponse.redirect(new URL("/verify-passkey", request.url));
+    }
+    return NextResponse.next();
+  }
+
+  // メール未認証ユーザーの制限
+  if (!token.emailVerified) {
+    if (isApiRoute) {
+      return NextResponse.json(
+        { error: "Email not verified" },
+        { status: 403 },
+      );
+    }
+    const emailVerificationAllowedRoutes = ["/check-email", "/verify-email"];
+    const isAllowed = emailVerificationAllowedRoutes.some(
+      (route) => pathname === route || pathname.startsWith(`${route}/`),
+    );
+    if (!isAllowed) {
+      return NextResponse.redirect(new URL("/check-email", request.url));
     }
     return NextResponse.next();
   }

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -58,16 +58,18 @@ function LoginForm() {
     });
 
     if (result?.error) {
-      if (result.error.includes("EMAIL_NOT_VERIFIED")) {
-        router.push(`/check-email?email=${encodeURIComponent(email)}`);
-        return;
-      }
       setError("メールアドレスまたはパスワードが正しくありません");
       setLoading(false);
       return;
     }
 
     const session = await getSession();
+
+    // メール未認証の場合は/check-emailへ
+    if (session?.user?.emailVerified === false) {
+      router.push("/check-email");
+      return;
+    }
 
     // パスキー2FA検証が必要な場合
     if (session?.user?.passkeyVerificationRequired) {

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
+import { signIn } from "next-auth/react";
 import { Suspense, useState } from "react";
 import { AuthLayout } from "@/components/auth/auth-layout";
 import { Button } from "@/components/ui/button";
@@ -71,7 +72,19 @@ function RegisterForm() {
         throw new Error(data.error || "登録に失敗しました");
       }
 
-      router.push(`/check-email?email=${encodeURIComponent(email)}`);
+      // 登録成功後に自動サインイン
+      const signInResult = await signIn("credentials", {
+        email,
+        password,
+        redirect: false,
+      });
+
+      if (signInResult?.ok) {
+        router.push("/check-email");
+      } else {
+        // サインイン失敗時はフォールバック
+        router.push(`/check-email?email=${encodeURIComponent(email)}`);
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : "登録に失敗しました");
     } finally {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -86,10 +86,6 @@ export const authOptions: NextAuthOptions = {
             return null;
           }
 
-          if (!account.emailVerified) {
-            throw new Error("EMAIL_NOT_VERIFIED");
-          }
-
           return {
             id: account.id,
             email: account.email,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,7 @@ declare module "next-auth" {
   interface User {
     accountType?: AccountType;
     passkeyVerificationRequired?: boolean;
+    emailVerified?: boolean;
   }
 
   interface Session {
@@ -25,6 +26,7 @@ declare module "next-auth" {
       companyRole?: CompanyRole;
       recruiterStatus?: CompanyMemberStatus;
       passkeyVerificationRequired?: boolean;
+      emailVerified?: boolean;
     };
   }
 }
@@ -34,6 +36,7 @@ declare module "next-auth/jwt" {
     email?: string;
     accountType?: AccountType;
     passkeyVerificationRequired?: boolean;
+    emailVerified?: boolean;
     accountId?: string;
     userId?: string;
     userName?: string;


### PR DESCRIPTION
## Summary

- 新規登録後に自動signInし、メール認証→パスキー設定推奨→ダッシュボードへのシームレスなフローを実現
- メール未認証ユーザーのページ・APIアクセスをmiddlewareで制限
- 別ブラウザで認証リンクを開いた場合は従来通りログインページへ誘導

## 変更フロー

**Before:**
```
登録 → check-email → メールリンク → verify-email → ログインページ → 手動ログイン → ダッシュボード
```

**After:**
```
登録 → 自動signIn → check-email（ログイン済み） → メールリンク → verify-email → セッション更新 → /setup/passkey → ダッシュボード
```

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/types/index.ts` | `User`, `JWT`, `Session` に `emailVerified` を追加 |
| `src/lib/auth.ts` | authorize関数でメール未認証でもセッション生成を許可、JWT/セッションに `emailVerified` を伝搬 |
| `middleware.ts` | メール未認証ユーザーのページ/APIアクセス制限（ページは `/check-email` へリダイレクト、APIは403） |
| `src/app/(auth)/register/page.tsx` | 登録成功後に `signIn()` で自動ログイン |
| `src/app/(auth)/verify-email/page.tsx` | セッションあり→`update()`→`/setup/passkey`、なし→「ログインする」リンク表示 |
| `src/app/(auth)/login/page.tsx` | `EMAIL_NOT_VERIFIED` エラーハンドリング削除、`emailVerified` チェックで `/check-email` へ誘導 |
| `src/app/(auth)/check-email/page.tsx` | `useSession()` でメール取得、認証済みならダッシュボードへリダイレクト |

## セキュリティ考慮

- middlewareでメール未認証ユーザーのアプリ・APIアクセスを制限（`/api/auth/`, `/api/webhooks/` は公開）
- JWTの `emailVerified` 更新は `useSession().update()` → jwtコールバック内でDB確認
- `window.location.href` による完全リロードでJWT更新タイミング問題を回避

## Test plan

- [ ] 新規登録 → 自動的にログイン状態で /check-email に遷移すること
- [ ] ログイン状態で /my/dashboard 等にアクセス → /check-email にリダイレクトされること
- [ ] メール内リンクをクリック → 認証成功 → /setup/passkey に遷移すること
- [ ] パスキー設定 or スキップ → ダッシュボードに遷移すること
- [ ] 別ブラウザでメールリンクをクリック → 認証成功 → 「ログインする」リンクが表示されること
- [ ] 未認証ユーザーがログインページからログイン → /check-email にリダイレクトされること
- [ ] メール未認証ユーザーがAPIに直接リクエスト → 403が返されること