### PR TITLE
feat: 音声チャットをPush-to-Talkから連続会話モードに統一

### DIFF
--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -178,67 +178,31 @@ export function ChatWindow({
             />
           </div>
           {/* マイクボタン */}
-          {voice.mode === "push-to-talk" ? (
-            <div className="relative">
-              {voice.voiceState === "recording" && (
-                <span className="absolute inset-0 rounded-md animate-ping bg-destructive/30" />
-              )}
-              <Button
-                type="button"
-                size="icon"
-                variant={
-                  voice.voiceState === "recording" ? "destructive" : "outline"
-                }
-                className={cn(
-                  "relative",
-                  voice.voiceState === "recording" &&
-                    "ring-2 ring-destructive/50",
-                )}
-                disabled={isVoiceBusy}
-                onPointerDown={voice.onPressStart}
-                onPointerUp={voice.onPressEnd}
-                onPointerLeave={
-                  voice.voiceState === "recording"
-                    ? voice.onPressEnd
-                    : undefined
-                }
-                title="押して話す"
-              >
-                <Mic className="size-4" />
-              </Button>
-            </div>
-          ) : voice.isActive ? (
-            <div className="relative">
-              {voice.voiceState === "recording" && (
-                <span className="absolute inset-0 rounded-md animate-ping bg-destructive/30" />
-              )}
-              <Button
-                type="button"
-                size="icon"
-                variant="destructive"
-                className={cn(
-                  "relative",
-                  voice.voiceState === "recording" &&
-                    "ring-2 ring-destructive/50",
-                )}
-                onClick={voice.toggleContinuous}
-                title="音声会話を停止"
-              >
-                <Square className="size-4" />
-              </Button>
-            </div>
-          ) : (
+          <div className="relative">
+            {voice.isActive && voice.voiceState === "recording" && (
+              <span className="absolute inset-0 rounded-md animate-ping bg-destructive/30" />
+            )}
             <Button
               type="button"
               size="icon"
-              variant="outline"
-              onClick={voice.toggleContinuous}
+              variant={voice.isActive ? "destructive" : "outline"}
+              className={cn(
+                "relative",
+                voice.isActive &&
+                  voice.voiceState === "recording" &&
+                  "ring-2 ring-destructive/50",
+              )}
+              onClick={voice.toggleVoice}
               disabled={isVoiceBusy}
-              title="連続会話を開始"
+              title={voice.isActive ? "音声会話を停止" : "音声会話を開始"}
             >
-              <Mic className="size-4" />
+              {voice.isActive ? (
+                <Square className="size-4" />
+              ) : (
+                <Mic className="size-4" />
+              )}
             </Button>
-          )}
+          </div>
           {/* 送信ボタン */}
           <Button
             type="submit"
@@ -250,23 +214,6 @@ export function ChatWindow({
           </Button>
         </div>
         <div className="flex items-center gap-2 mt-2">
-          <button
-            type="button"
-            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-            onClick={() =>
-              voice.setMode(
-                voice.mode === "push-to-talk" ? "continuous" : "push-to-talk",
-              )
-            }
-            disabled={voice.isActive}
-            title={
-              voice.mode === "push-to-talk"
-                ? "連続会話モードに切替"
-                : "Push-to-talkモードに切替"
-            }
-          >
-            {voice.mode === "push-to-talk" ? "PTT" : "連続"}
-          </button>
           <span className="text-xs text-muted-foreground">
             {voice.voiceState === "recording"
               ? formatDuration(voice.duration)

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -106,7 +106,7 @@ export function ChatWindow({
   );
 
   const isVoiceBusy =
-    voice.voiceState !== "inactive" && voice.voiceState !== "recording";
+    voice.voiceState === "transcribing" || voice.voiceState === "waiting";
 
   return (
     <div className="flex flex-col h-full">

--- a/src/hooks/__tests__/useVoiceRecording.test.ts
+++ b/src/hooks/__tests__/useVoiceRecording.test.ts
@@ -41,7 +41,7 @@ const mockTrackStop = vi.fn();
 // AudioContext モック
 const mockGetByteTimeDomainData = vi.fn();
 const mockConnect = vi.fn();
-const mockClose = vi.fn();
+const mockClose = vi.fn().mockResolvedValue(undefined);
 
 const mockAnalyser = {
   fftSize: 2048,

--- a/src/hooks/useVoiceConversation.ts
+++ b/src/hooks/useVoiceConversation.ts
@@ -148,14 +148,19 @@ export function useVoiceConversation({
     if (isActive) {
       isActiveRef.current = false;
       setIsActive(false);
-      recordingRef.current
-        ?.stopRecording()
+      const rec = recordingRef.current;
+      if (!rec) {
+        setVoiceState("inactive");
+        return;
+      }
+      rec
+        .stopRecording()
         .then(() => {
-          recordingRef.current?.releaseStream();
+          rec.releaseStream();
           setVoiceState("inactive");
         })
         .catch(() => {
-          recordingRef.current?.releaseStream();
+          rec.releaseStream();
           setVoiceState("inactive");
         });
     } else {
@@ -163,14 +168,21 @@ export function useVoiceConversation({
       isActiveRef.current = true;
       setIsActive(true);
       setVoiceState("recording");
-      recordingRef.current
-        ?.acquireStream()
+      const rec = recordingRef.current;
+      if (!rec) {
+        setIsActive(false);
+        isActiveRef.current = false;
+        setVoiceState("inactive");
+        return;
+      }
+      rec
+        .acquireStream()
         .then(() => {
-          return recordingRef.current?.startRecording();
+          return rec.startRecording();
         })
         .catch(() => {
           setError("録音の開始に失敗しました");
-          recordingRef.current?.releaseStream();
+          rec.releaseStream();
           setIsActive(false);
           isActiveRef.current = false;
           setVoiceState("inactive");


### PR DESCRIPTION
## Summary

- PTT(Push-to-Talk)モードを削除し、連続会話モード（自動録音→無音検知→文字起こし→AI応答→自動再開）を唯一のモードに統一
- MediaStreamを会話中永続化し、録音サイクルごとのストリーム再取得を排除（遅延・非効率を解消）
- マイクボタンUIを3分岐から1つのトグルボタンに簡素化

## 変更内容

### `useVoiceRecording.ts`
- `cleanup`を`cleanupRecording()`（録音のみ停止）と`cleanupStream()`（全リソース解放）に分割
- `acquireStream()` / `releaseStream()` を新規追加
- `silenceDuration`デフォルトを3000ms→1500msに短縮
- `track.onended`でストリーム切断検知 + 自動クリーンアップ

### `useVoiceConversation.ts`
- `VoiceMode`型、`mode` state、`onPressStart`、`onPressEnd`を完全削除
- `toggleContinuous` → `toggleVoice`にリネーム・簡素化
- transcribe空/失敗時に録音を自動再開するよう修正
- ストリームエラー復帰useEffect追加

### `ChatWindow.tsx`
- PTT用ボタン（`onPointerDown`/`onPointerUp`）を完全削除
- トグルボタン1つに統合（非アクティブ: Mic + outline、アクティブ: Square + destructive）
- モード切替テキストボタン（"PTT" / "連続"）を削除

### `useVoiceRecording.test.ts`
- `stopRecording`でストリームが維持されることを確認するテスト更新
- `acquireStream` / `releaseStream` / ストリーム再利用の3テスト追加（計11テスト全パス）

## Test plan

- [x] `npm run check` — Biome lint/format通過
- [x] `npx tsc --noEmit` — 型チェック通過
- [x] `npx vitest run src/hooks/__tests__/useVoiceRecording.test.ts` — 11テスト全パス
- [ ] ブラウザ手動確認: マイクボタンクリックで連続会話開始→発話→無音1.5秒→自動文字起こし・送信→AI応答後自動録音再開→停止ボタンで終了