### PR TITLE
develop → main マージ

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -296,7 +296,9 @@ jobs:
             {"name":"DOCUMENT_ANALYSIS_LAMBDA_ARN","valueFrom":"'"$SSM_PREFIX"'/document-analysis-lambda-arn"},
             {"name":"ANALYSIS_CALLBACK_SECRET","valueFrom":"'"$SSM_PREFIX"'/analysis-callback-secret"},
             {"name":"WEBAUTHN_RP_ID","valueFrom":"'"$SSM_PREFIX"'/webauthn-rp-id"},
-            {"name":"WEBAUTHN_ORIGIN","valueFrom":"'"$SSM_PREFIX"'/webauthn-origin"}
+            {"name":"WEBAUTHN_ORIGIN","valueFrom":"'"$SSM_PREFIX"'/webauthn-origin"},
+            {"name":"RESEND_API_KEY","valueFrom":"'"$SSM_PREFIX"'/resend-api-key"},
+            {"name":"EMAIL_FROM","valueFrom":"'"$SSM_PREFIX"'/email-from"}
           ]'
           NEW_TASK_DEF=$(echo "$TASK_DEF" | jq \
             --arg IMAGE "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" \

--- a/middleware.ts
+++ b/middleware.ts
@@ -29,10 +29,12 @@ export async function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // 認証不要のAPIルート
+  // 認証不要のAPIルート（公開認証API、Webhook、ヘルスチェック、内部API）
+  // 内部APIは独自のAPIキー認証を使用するため、JWTチェックをバイパス
   if (
     pathname.startsWith("/api/auth/") ||
     pathname.startsWith("/api/webhooks/") ||
+    pathname.startsWith("/api/internal/") ||
     pathname === "/api/health"
   ) {
     return NextResponse.next();

--- a/middleware.ts
+++ b/middleware.ts
@@ -72,7 +72,7 @@ export async function middleware(request: NextRequest) {
 
   // メール未認証ユーザーの制限
   // /check-email, /verify-email は publicRoutes で処理済みのためここには到達しない
-  if (!token.emailVerified) {
+  if (token.emailVerified === false) {
     if (isApiRoute) {
       return NextResponse.json(
         { error: "Email not verified" },

--- a/middleware.ts
+++ b/middleware.ts
@@ -29,10 +29,11 @@ export async function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // 認証系APIは公開
+  // 認証不要のAPIルート
   if (
     pathname.startsWith("/api/auth/") ||
-    pathname.startsWith("/api/webhooks/")
+    pathname.startsWith("/api/webhooks/") ||
+    pathname === "/api/health"
   ) {
     return NextResponse.next();
   }

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,4 +5,12 @@ const nextConfig: NextConfig = {
   serverExternalPackages: ["pdf-to-img", "pdfjs-dist", "sharp"],
 };
 
-export default nextConfig;
+export default async (): Promise<NextConfig> => {
+  if (process.env.ANALYZE === "true") {
+    const withBundleAnalyzer = (await import("@next/bundle-analyzer")).default({
+      enabled: true,
+    });
+    return withBundleAnalyzer(nextConfig);
+  }
+  return nextConfig;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.3.11",
+        "@next/bundle-analyzer": "^16.1.6",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -1517,6 +1518,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/@discoveryjs/json-ext": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
@@ -2968,6 +2979,16 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@next/bundle-analyzer": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-16.1.6.tgz",
+      "integrity": "sha512-ee2kagdTaeEWPlotgdTOqFHYcD3e2m2bbE3I9Rq2i6ABYi5OgopmtEUe8NM23viaYxLV2tDH/2nd5+qKoEr6cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webpack-bundle-analyzer": "4.10.1"
+      }
+    },
     "node_modules/@next/env": {
       "version": "16.1.6",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.6.tgz",
@@ -3336,6 +3357,13 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@prisma/client": {
       "version": "6.19.2",
@@ -7351,6 +7379,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -8049,6 +8090,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -8249,6 +8300,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -8437,6 +8495,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/effect": {
       "version": "3.18.4",
@@ -9639,6 +9704,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/gzip-size": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -9758,6 +9839,13 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -10152,6 +10240,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -11293,6 +11391,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -11671,6 +11779,16 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
       }
     },
     "node_modules/openid-client": {
@@ -12857,6 +12975,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/sirv": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
+      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -13365,6 +13498,16 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tough-cookie": {
@@ -15001,6 +15144,56 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.1.tgz",
+      "integrity": "sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@discoveryjs/json-ext": "0.5.7",
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "commander": "^7.2.0",
+        "debounce": "^1.2.1",
+        "escape-string-regexp": "^4.0.0",
+        "gzip-size": "^6.0.0",
+        "html-escaper": "^2.0.2",
+        "is-plain-object": "^5.0.0",
+        "opener": "^1.5.2",
+        "picocolors": "^1.0.0",
+        "sirv": "^2.0.3",
+        "ws": "^7.3.1"
+      },
+      "bin": {
+        "webpack-bundle-analyzer": "lib/bin/analyzer.js"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/whatwg-mimetype": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "db:migrate": "prisma migrate dev",
     "db:studio": "prisma studio",
     "db:seed": "npx tsx prisma/seed.ts",
+    "analyze": "ANALYZE=true next build",
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
@@ -59,6 +60,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.11",
+    "@next/bundle-analyzer": "^16.1.6",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/prisma/migrations/20260221000000_add_performance_indexes/migration.sql
+++ b/prisma/migrations/20260221000000_add_performance_indexes/migration.sql
@@ -1,0 +1,20 @@
+-- CreateIndex
+CREATE INDEX "Session_recruiterId_agentId_sessionType_idx" ON "Session"("recruiterId", "agentId", "sessionType");
+
+-- CreateIndex
+CREATE INDEX "Session_userId_sessionType_idx" ON "Session"("userId", "sessionType");
+
+-- CreateIndex
+CREATE INDEX "Message_sessionId_createdAt_idx" ON "Message"("sessionId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "Fragment_userId_idx" ON "Fragment"("userId");
+
+-- CreateIndex
+CREATE INDEX "Document_userId_idx" ON "Document"("userId");
+
+-- CreateIndex
+CREATE INDEX "JobPosting_recruiterId_idx" ON "JobPosting"("recruiterId");
+
+-- CreateIndex
+CREATE INDEX "MessageReference_messageId_idx" ON "MessageReference"("messageId");

--- a/prisma/migrations/20260222000000_add_fragment_source_index/migration.sql
+++ b/prisma/migrations/20260222000000_add_fragment_source_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "Fragment_sourceType_sourceId_idx" ON "Fragment"("sourceType", "sourceId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -266,6 +266,7 @@ model Fragment {
   createdAt    DateTime     @default(now())
 
   @@index([userId])
+  @@index([sourceType, sourceId])
 }
 
 model AgentProfile {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -225,6 +225,8 @@ model Document {
   analysisError   String?
   analyzedAt      DateTime?
   createdAt       DateTime       @default(now())
+
+  @@index([userId])
 }
 
 model Experience {
@@ -262,6 +264,8 @@ model Fragment {
   sourceId     String?
   confidence   Float        @default(1.0)
   createdAt    DateTime     @default(now())
+
+  @@index([userId])
 }
 
 model AgentProfile {
@@ -293,6 +297,9 @@ model Session {
   messages   Message[]
   notes      InterviewNote[]
   evaluation InterviewEvaluation?
+
+  @@index([recruiterId, agentId, sessionType])
+  @@index([userId, sessionType])
 }
 
 model Message {
@@ -305,6 +312,8 @@ model Message {
   createdAt  DateTime   @default(now())
 
   references MessageReference[]
+
+  @@index([sessionId, createdAt])
 }
 
 model MessageReference {
@@ -313,6 +322,8 @@ model MessageReference {
   message   Message @relation(fields: [messageId], references: [id])
   refType   RefType
   refId     String
+
+  @@index([messageId])
 }
 
 model Tag {
@@ -416,6 +427,8 @@ model JobPosting {
   matches   CandidateMatch[]
   pipelines CandidatePipeline[]
   watches   CandidateWatch[]
+
+  @@index([recruiterId])
 }
 
 // ==========================================

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -1,0 +1,230 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// next-auth/jwt モック
+const mockGetToken = vi.fn();
+vi.mock("next-auth/jwt", () => ({
+  getToken: (...args: unknown[]) => mockGetToken(...args),
+}));
+
+// middleware を動的インポート（モック適用後）
+async function getMiddleware() {
+  const mod = await import("../../middleware");
+  return mod.middleware;
+}
+
+function createRequest(pathname: string, baseUrl = "http://localhost:3000") {
+  return new NextRequest(new URL(pathname, baseUrl));
+}
+
+function validToken(overrides = {}) {
+  return {
+    email: "test@example.com",
+    accountType: "USER",
+    emailVerified: true,
+    passkeyVerificationRequired: false,
+    ...overrides,
+  };
+}
+
+describe("middleware", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetToken.mockResolvedValue(null);
+  });
+
+  // ── 公開ルート ──────────────────────────────────────────
+
+  describe("公開ルート（認証不要）", () => {
+    it.each([
+      "/",
+      "/login",
+      "/register",
+      "/invite",
+      "/check-email",
+      "/verify-email",
+    ])("%s はそのまま通過する", async (path) => {
+      const middleware = await getMiddleware();
+      const res = await middleware(createRequest(path));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("x-middleware-rewrite")).toBeFalsy();
+    });
+
+    it("公開ルートのサブパスも通過する（/invite/abc）", async () => {
+      const middleware = await getMiddleware();
+      const res = await middleware(createRequest("/invite/abc"));
+      expect(res.status).toBe(200);
+    });
+
+    it("静的ファイル（拡張子付き）はスキップする", async () => {
+      const middleware = await getMiddleware();
+      const res = await middleware(createRequest("/image.png"));
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // ── 認証不要のAPIルート ────────────────────────────────
+
+  describe("認証不要のAPIルート", () => {
+    it("/api/auth/* はJWTなしで通過する", async () => {
+      const middleware = await getMiddleware();
+      const res = await middleware(createRequest("/api/auth/register"));
+      expect(res.status).toBe(200);
+    });
+
+    it("/api/webhooks/* はJWTなしで通過する", async () => {
+      const middleware = await getMiddleware();
+      const res = await middleware(createRequest("/api/webhooks/stripe"));
+      expect(res.status).toBe(200);
+    });
+
+    it("/api/health はJWTなしで通過する", async () => {
+      const middleware = await getMiddleware();
+      const res = await middleware(createRequest("/api/health"));
+      expect(res.status).toBe(200);
+    });
+
+    it("/api/internal/* はJWTなしで通過する（APIキー認証を使用）", async () => {
+      const middleware = await getMiddleware();
+      const res = await middleware(
+        createRequest("/api/internal/analysis-callback"),
+      );
+      expect(res.status).toBe(200);
+    });
+
+    it("/api/internal/expire-points はJWTなしで通過する", async () => {
+      const middleware = await getMiddleware();
+      const res = await middleware(
+        createRequest("/api/internal/expire-points"),
+      );
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // ── 未認証アクセス ────────────────────────────────────
+
+  describe("未認証アクセス", () => {
+    it("保護されたページは/loginにリダイレクトされる", async () => {
+      const middleware = await getMiddleware();
+      const res = await middleware(createRequest("/my/dashboard"));
+      expect(res.status).toBe(307);
+      const location = res.headers.get("location");
+      expect(location).toContain("/login");
+      expect(location).toContain("callbackUrl=%2Fmy%2Fdashboard");
+    });
+
+    it("保護されたAPIは401を返す", async () => {
+      const middleware = await getMiddleware();
+      const res = await middleware(createRequest("/api/agents/me"));
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // ── 2FA検証 ───────────────────────────────────────────
+
+  describe("2FA検証が必要な場合", () => {
+    beforeEach(() => {
+      mockGetToken.mockResolvedValue(
+        validToken({ passkeyVerificationRequired: true }),
+      );
+    });
+
+    it("APIルートは403を返す", async () => {
+      const middleware = await getMiddleware();
+      const res = await middleware(createRequest("/api/agents/me"));
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toContain("2FA");
+    });
+
+    it("/verify-passkeyは通過する", async () => {
+      const middleware = await getMiddleware();
+      const res = await middleware(createRequest("/verify-passkey"));
+      expect(res.status).toBe(200);
+    });
+
+    it("その他のページは/verify-passkeyにリダイレクトされる", async () => {
+      const middleware = await getMiddleware();
+      const res = await middleware(createRequest("/my/dashboard"));
+      expect(res.status).toBe(307);
+      expect(res.headers.get("location")).toContain("/verify-passkey");
+    });
+  });
+
+  // ── メール未認証 ──────────────────────────────────────
+
+  describe("メール未認証ユーザー", () => {
+    beforeEach(() => {
+      mockGetToken.mockResolvedValue(validToken({ emailVerified: false }));
+    });
+
+    it("APIルートは403を返す", async () => {
+      const middleware = await getMiddleware();
+      const res = await middleware(createRequest("/api/agents/me"));
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toContain("Email not verified");
+    });
+
+    it("ページは/check-emailにリダイレクトされる", async () => {
+      const middleware = await getMiddleware();
+      const res = await middleware(createRequest("/my/dashboard"));
+      expect(res.status).toBe(307);
+      expect(res.headers.get("location")).toContain("/check-email");
+    });
+  });
+
+  // ── ロールベースルーティング ───────────────────────────
+
+  describe("ロールベースルーティング", () => {
+    it("RECRUITERが/myにアクセスすると/recruiter/dashboardにリダイレクト", async () => {
+      mockGetToken.mockResolvedValue(validToken({ accountType: "RECRUITER" }));
+      const middleware = await getMiddleware();
+      const res = await middleware(createRequest("/my/dashboard"));
+      expect(res.status).toBe(307);
+      expect(res.headers.get("location")).toContain("/recruiter/dashboard");
+    });
+
+    it("USERが/recruiterにアクセスすると/my/dashboardにリダイレクト", async () => {
+      mockGetToken.mockResolvedValue(validToken({ accountType: "USER" }));
+      const middleware = await getMiddleware();
+      const res = await middleware(createRequest("/recruiter/dashboard"));
+      expect(res.status).toBe(307);
+      expect(res.headers.get("location")).toContain("/my/dashboard");
+    });
+
+    it("USERが/my/dashboardに正常アクセスできる", async () => {
+      mockGetToken.mockResolvedValue(validToken({ accountType: "USER" }));
+      const middleware = await getMiddleware();
+      const res = await middleware(createRequest("/my/dashboard"));
+      expect(res.status).toBe(200);
+    });
+
+    it("RECRUITERが/recruiter/dashboardに正常アクセスできる", async () => {
+      mockGetToken.mockResolvedValue(validToken({ accountType: "RECRUITER" }));
+      const middleware = await getMiddleware();
+      const res = await middleware(createRequest("/recruiter/dashboard"));
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // ── /verify-passkey の不要アクセス ─────────────────────
+
+  describe("/verify-passkey の不要アクセス", () => {
+    it("2FA不要のUSERはダッシュボードにリダイレクトされる", async () => {
+      mockGetToken.mockResolvedValue(validToken({ accountType: "USER" }));
+      const middleware = await getMiddleware();
+      const res = await middleware(createRequest("/verify-passkey"));
+      expect(res.status).toBe(307);
+      expect(res.headers.get("location")).toContain("/my/dashboard");
+    });
+
+    it("2FA不要のRECRUITERはリクルーターダッシュボードにリダイレクトされる", async () => {
+      mockGetToken.mockResolvedValue(validToken({ accountType: "RECRUITER" }));
+      const middleware = await getMiddleware();
+      const res = await middleware(createRequest("/verify-passkey"));
+      expect(res.status).toBe(307);
+      expect(res.headers.get("location")).toContain("/recruiter/dashboard");
+    });
+  });
+});

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -58,16 +58,18 @@ function LoginForm() {
     });
 
     if (result?.error) {
-      if (result.error.includes("EMAIL_NOT_VERIFIED")) {
-        router.push(`/check-email?email=${encodeURIComponent(email)}`);
-        return;
-      }
       setError("メールアドレスまたはパスワードが正しくありません");
       setLoading(false);
       return;
     }
 
     const session = await getSession();
+
+    // メール未認証の場合は/check-emailへ
+    if (session?.user?.emailVerified === false) {
+      router.push("/check-email");
+      return;
+    }
 
     // パスキー2FA検証が必要な場合
     if (session?.user?.passkeyVerificationRequired) {

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
+import { signIn } from "next-auth/react";
 import { Suspense, useState } from "react";
 import { AuthLayout } from "@/components/auth/auth-layout";
 import { Button } from "@/components/ui/button";
@@ -71,7 +72,19 @@ function RegisterForm() {
         throw new Error(data.error || "登録に失敗しました");
       }
 
-      router.push(`/check-email?email=${encodeURIComponent(email)}`);
+      // 登録成功後に自動サインイン
+      const signInResult = await signIn("credentials", {
+        email,
+        password,
+        redirect: false,
+      });
+
+      if (signInResult?.ok) {
+        router.push("/check-email");
+      } else {
+        // サインイン失敗時はフォールバック
+        router.push(`/check-email?email=${encodeURIComponent(email)}`);
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : "登録に失敗しました");
     } finally {

--- a/src/app/(auth)/verify-email/page.tsx
+++ b/src/app/(auth)/verify-email/page.tsx
@@ -4,47 +4,73 @@ import { CheckCircle2, XCircle } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import { Suspense, useEffect, useState } from "react";
+import { useSession } from "next-auth/react";
+import { Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 
 function VerifyEmailContent() {
   const searchParams = useSearchParams();
   const token = searchParams.get("token") || "";
+  const { data: session, status: sessionStatus, update } = useSession();
   const [status, setStatus] = useState<"loading" | "success" | "error">(
     "loading",
   );
   const [errorMessage, setErrorMessage] = useState("");
+  const hasVerified = useRef(false);
 
+  const handleVerify = useCallback(async () => {
+    if (hasVerified.current) return;
+    hasVerified.current = true;
+
+    try {
+      const res = await fetch("/api/auth/verify-email", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token }),
+      });
+
+      if (res.ok) {
+        setStatus("success");
+      } else {
+        const data = await res.json();
+        setStatus("error");
+        setErrorMessage(data.error || "認証に失敗しました");
+      }
+    } catch {
+      setStatus("error");
+      setErrorMessage("認証に失敗しました");
+    }
+  }, [token]);
+
+  // トークン検証
   useEffect(() => {
     if (!token) {
       setStatus("error");
       setErrorMessage("認証トークンがありません");
       return;
     }
+    handleVerify();
+  }, [token, handleVerify]);
 
-    const verify = async () => {
-      try {
-        const res = await fetch("/api/auth/verify-email", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ token }),
-        });
+  // 認証成功後、セッションがあればJWTを更新してリダイレクト
+  const hasRedirected = useRef(false);
+  useEffect(() => {
+    if (
+      status !== "success" ||
+      sessionStatus === "loading" ||
+      hasRedirected.current
+    )
+      return;
+    if (!session) return; // セッションなし = 別ブラウザでの認証
+    hasRedirected.current = true;
 
-        if (res.ok) {
-          setStatus("success");
-        } else {
-          const data = await res.json();
-          setStatus("error");
-          setErrorMessage(data.error || "認証に失敗しました");
-        }
-      } catch {
-        setStatus("error");
-        setErrorMessage("認証に失敗しました");
-      }
+    const redirectAfterUpdate = async () => {
+      await update();
+      // 完全リロードでmiddlewareが最新JWTを読み取れるようにする
+      window.location.href = "/setup/passkey";
     };
-
-    verify();
-  }, [token]);
+    redirectAfterUpdate();
+  }, [status, session, sessionStatus, update]);
 
   return (
     <div className="flex min-h-dvh items-center justify-center bg-background px-4">
@@ -76,13 +102,25 @@ function VerifyEmailContent() {
               <h1 className="text-xl font-bold tracking-tight">
                 認証が完了しました
               </h1>
-              <p className="text-sm text-muted-foreground">
-                メールアドレスの認証が完了しました。ログインしてご利用ください。
-              </p>
+              {sessionStatus === "loading" ? (
+                <p className="text-sm text-muted-foreground">
+                  メールアドレスの認証が完了しました。リダイレクト準備中...
+                </p>
+              ) : session ? (
+                <p className="text-sm text-muted-foreground">
+                  メールアドレスの認証が完了しました。リダイレクトしています...
+                </p>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  メールアドレスの認証が完了しました。ログインしてご利用ください。
+                </p>
+              )}
             </div>
-            <Button asChild className="w-full">
-              <Link href="/login">ログインする</Link>
-            </Button>
+            {sessionStatus === "unauthenticated" && (
+              <Button asChild className="w-full">
+                <Link href="/login">ログインする</Link>
+              </Button>
+            )}
           </div>
         )}
 

--- a/src/app/api/agents/me/route.ts
+++ b/src/app/api/agents/me/route.ts
@@ -150,8 +150,8 @@ export const GET = withUserAuth(async (req, session) => {
 });
 
 const updateAgentSchema = z.object({
-  systemPrompt: z.string().optional(),
-  status: z.enum(["DRAFT", "PUBLIC", "PRIVATE"]).optional(),
+  systemPrompt: z.string().max(10000).optional(),
+  status: z.enum(["PUBLIC", "PRIVATE"]).optional(),
 });
 
 export const PATCH = withUserAuth(async (req, session) => {
@@ -173,7 +173,7 @@ export const PATCH = withUserAuth(async (req, session) => {
   }
 
   if (status !== undefined) {
-    updateData.status = status as AgentStatus;
+    updateData.status = status;
   }
 
   // 現在のステータスを取得

--- a/src/app/api/agents/public/route.ts
+++ b/src/app/api/agents/public/route.ts
@@ -39,6 +39,7 @@ export const GET = withRecruiterAuth(async (request, session) => {
       },
     },
     orderBy: { updatedAt: "desc" },
+    take: 100,
   });
 
   // 求人フィルタがある場合

--- a/src/app/api/applicant/avatar/[path]/__tests__/avatar.test.ts
+++ b/src/app/api/applicant/avatar/[path]/__tests__/avatar.test.ts
@@ -1,0 +1,138 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// NextAuth モック
+const mockGetServerSession = vi.fn();
+vi.mock("next-auth", () => ({
+  getServerSession: () => mockGetServerSession(),
+}));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+
+// Logger モック
+const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+vi.mock("@/lib/logger", () => ({ logger: mockLogger }));
+
+// MinIO モック
+const mockGetFileUrl = vi.fn();
+vi.mock("@/lib/minio", () => ({
+  getFileUrl: (...args: unknown[]) => mockGetFileUrl(...args),
+}));
+
+const authenticatedSession = {
+  user: { accountId: "acc-1", email: "test@example.com" },
+};
+
+function createRequest(): NextRequest {
+  return new NextRequest(
+    "http://localhost/api/applicant/avatar/avatars/test.png",
+    {
+      method: "GET",
+    },
+  );
+}
+
+describe("GET /api/applicant/avatar/[path]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(authenticatedSession);
+    mockGetFileUrl.mockResolvedValue("https://minio.example.com/presigned-url");
+  });
+
+  describe("認証", () => {
+    it("未認証の場合は401を返す", async () => {
+      mockGetServerSession.mockResolvedValue(null);
+      const { GET } = await import("@/app/api/applicant/avatar/[path]/route");
+
+      const res = await GET(createRequest(), {
+        params: Promise.resolve({ path: "avatars/test.png" }),
+      });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("パスバリデーション", () => {
+    it("avatars/で始まらないパスは404を返す", async () => {
+      const { GET } = await import("@/app/api/applicant/avatar/[path]/route");
+
+      const res = await GET(createRequest(), {
+        params: Promise.resolve({ path: "documents/secret.pdf" }),
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("空のパスは404を返す", async () => {
+      const { GET } = await import("@/app/api/applicant/avatar/[path]/route");
+
+      const res = await GET(createRequest(), {
+        params: Promise.resolve({ path: "" }),
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("パストラバーサル（avatars/../）は404を返す", async () => {
+      const { GET } = await import("@/app/api/applicant/avatar/[path]/route");
+
+      const res = await GET(createRequest(), {
+        params: Promise.resolve({ path: "avatars/../documents/secret.pdf" }),
+      });
+      expect(res.status).toBe(404);
+      // getFileUrlは呼ばれない
+      expect(mockGetFileUrl).not.toHaveBeenCalled();
+    });
+
+    it("パストラバーサル（avatars/../../etc/passwd）は404を返す", async () => {
+      const { GET } = await import("@/app/api/applicant/avatar/[path]/route");
+
+      const res = await GET(createRequest(), {
+        params: Promise.resolve({ path: "avatars/../../etc/passwd" }),
+      });
+      expect(res.status).toBe(404);
+      expect(mockGetFileUrl).not.toHaveBeenCalled();
+    });
+
+    it("パストラバーサル（avatars/sub/../../secret）は404を返す", async () => {
+      const { GET } = await import("@/app/api/applicant/avatar/[path]/route");
+
+      const res = await GET(createRequest(), {
+        params: Promise.resolve({
+          path: "avatars/sub/../../secret.txt",
+        }),
+      });
+      expect(res.status).toBe(404);
+      expect(mockGetFileUrl).not.toHaveBeenCalled();
+    });
+
+    it("冗長なスラッシュは正規化して処理する", async () => {
+      const { GET } = await import("@/app/api/applicant/avatar/[path]/route");
+
+      const res = await GET(createRequest(), {
+        params: Promise.resolve({ path: "avatars//test.png" }),
+      });
+      // 正規化後 "avatars/test.png" になるのでOK
+      expect(res.status).toBe(307);
+      expect(mockGetFileUrl).toHaveBeenCalledWith("avatars/test.png");
+    });
+  });
+
+  describe("正常系", () => {
+    it("正常なパスの場合はpresigned URLにリダイレクトする", async () => {
+      const { GET } = await import("@/app/api/applicant/avatar/[path]/route");
+
+      const res = await GET(createRequest(), {
+        params: Promise.resolve({ path: "avatars/abc123-photo.png" }),
+      });
+      expect(res.status).toBe(307);
+      expect(mockGetFileUrl).toHaveBeenCalledWith("avatars/abc123-photo.png");
+    });
+
+    it("サブディレクトリも許可する", async () => {
+      const { GET } = await import("@/app/api/applicant/avatar/[path]/route");
+
+      const res = await GET(createRequest(), {
+        params: Promise.resolve({ path: "avatars/user1/photo.jpg" }),
+      });
+      expect(res.status).toBe(307);
+      expect(mockGetFileUrl).toHaveBeenCalledWith("avatars/user1/photo.jpg");
+    });
+  });
+});

--- a/src/app/api/applicant/avatar/[path]/route.ts
+++ b/src/app/api/applicant/avatar/[path]/route.ts
@@ -1,3 +1,4 @@
+import nodePath from "node:path";
 import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/api-utils";
 import { NotFoundError } from "@/lib/errors";
@@ -12,7 +13,13 @@ export const GET = withAuth(
       throw new NotFoundError("画像が見つかりません");
     }
 
-    const url = await getFileUrl(path);
+    // パストラバーサル防止: ".." を含むパスや正規化後にavatars/外になるパスを拒否
+    const normalized = nodePath.posix.normalize(path);
+    if (!normalized.startsWith("avatars/") || normalized.includes("..")) {
+      throw new NotFoundError("画像が見つかりません");
+    }
+
+    const url = await getFileUrl(normalized);
     return NextResponse.redirect(url);
   },
 );

--- a/src/app/api/applicant/avatar/[path]/route.ts
+++ b/src/app/api/applicant/avatar/[path]/route.ts
@@ -1,14 +1,14 @@
 import { NextResponse } from "next/server";
-import { withErrorHandling } from "@/lib/api-utils";
+import { withAuth } from "@/lib/api-utils";
 import { NotFoundError } from "@/lib/errors";
 import { getFileUrl } from "@/lib/minio";
 
 // アバター画像を配信（presigned URL へリダイレクト）
-export const GET = withErrorHandling(
-  async (_req, context: { params: Promise<{ path: string }> }) => {
+export const GET = withAuth(
+  async (_req, session, context: { params: Promise<{ path: string }> }) => {
     const { path } = await context.params;
 
-    if (!path) {
+    if (!path || !path.startsWith("avatars/")) {
       throw new NotFoundError("画像が見つかりません");
     }
 

--- a/src/app/api/applicant/company-access/__tests__/company-access.test.ts
+++ b/src/app/api/applicant/company-access/__tests__/company-access.test.ts
@@ -1,0 +1,301 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mocks ──────────────────────────────────────────────────────────
+
+const mockGetServerSession = vi.fn();
+vi.mock("next-auth", () => ({
+  getServerSession: () => mockGetServerSession(),
+}));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+
+const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+vi.mock("@/lib/logger", () => ({ logger: mockLogger }));
+
+const mockPrisma = {
+  companyAccess: {
+    findMany: vi.fn(),
+    upsert: vi.fn(),
+    findUnique: vi.fn(),
+    delete: vi.fn(),
+  },
+  company: {
+    findUnique: vi.fn(),
+  },
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+// ── Constants ──────────────────────────────────────────────────────
+
+const USER_ID = "user-001";
+const ACCOUNT_ID = "acc-1";
+const COMPANY_ID = "company-001";
+const ACCESS_ID = "access-001";
+
+const userSession = {
+  user: {
+    accountId: ACCOUNT_ID,
+    userId: USER_ID,
+    accountType: "USER",
+  },
+};
+
+const mockCompany = {
+  id: COMPANY_ID,
+  name: "テスト株式会社",
+};
+
+const mockAccessRecord = {
+  id: ACCESS_ID,
+  userId: USER_ID,
+  companyId: COMPANY_ID,
+  status: "ALLOW",
+  createdAt: new Date("2024-01-01"),
+  updatedAt: new Date("2024-01-01"),
+  company: { id: COMPANY_ID, name: "テスト株式会社" },
+};
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function createGetRequest(): NextRequest {
+  return new NextRequest("http://localhost/api/applicant/company-access", {
+    method: "GET",
+  });
+}
+
+function createPatchRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/applicant/company-access", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function createDeleteRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/applicant/company-access", {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// ── GET Tests ──────────────────────────────────────────────────────
+
+describe("GET /api/applicant/company-access", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(userSession);
+  });
+
+  it("アクセス設定一覧を返す", async () => {
+    mockPrisma.companyAccess.findMany.mockResolvedValue([mockAccessRecord]);
+
+    const { GET } = await import("@/app/api/applicant/company-access/route");
+    const response = await GET(createGetRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.accessList).toHaveLength(1);
+    expect(data.accessList[0].companyId).toBe(COMPANY_ID);
+    expect(data.accessList[0].companyName).toBe("テスト株式会社");
+    expect(data.accessList[0].status).toBe("ALLOW");
+  });
+
+  it("自分のuserIdでフィルタする", async () => {
+    mockPrisma.companyAccess.findMany.mockResolvedValue([]);
+
+    const { GET } = await import("@/app/api/applicant/company-access/route");
+    await GET(createGetRequest());
+
+    expect(mockPrisma.companyAccess.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: USER_ID },
+      }),
+    );
+  });
+
+  it("空の一覧を返せる", async () => {
+    mockPrisma.companyAccess.findMany.mockResolvedValue([]);
+
+    const { GET } = await import("@/app/api/applicant/company-access/route");
+    const response = await GET(createGetRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.accessList).toHaveLength(0);
+  });
+
+  it("未認証の場合401を返す", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const { GET } = await import("@/app/api/applicant/company-access/route");
+    const response = await GET(createGetRequest());
+
+    expect(response.status).toBe(401);
+  });
+});
+
+// ── PATCH Tests ────────────────────────────────────────────────────
+
+describe("PATCH /api/applicant/company-access", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(userSession);
+    mockPrisma.company.findUnique.mockResolvedValue(mockCompany);
+    mockPrisma.companyAccess.upsert.mockResolvedValue(mockAccessRecord);
+  });
+
+  it("ALLOWステータスでアクセス設定を作成/更新できる", async () => {
+    const { PATCH } = await import("@/app/api/applicant/company-access/route");
+    const response = await PATCH(
+      createPatchRequest({ companyId: COMPANY_ID, status: "ALLOW" }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.companyId).toBe(COMPANY_ID);
+    expect(data.status).toBe("ALLOW");
+  });
+
+  it("DENYステータスでアクセス設定を作成/更新できる", async () => {
+    mockPrisma.companyAccess.upsert.mockResolvedValue({
+      ...mockAccessRecord,
+      status: "DENY",
+    });
+
+    const { PATCH } = await import("@/app/api/applicant/company-access/route");
+    const response = await PATCH(
+      createPatchRequest({ companyId: COMPANY_ID, status: "DENY" }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.status).toBe("DENY");
+  });
+
+  it("upsertで自分のuserIdを使用する", async () => {
+    const { PATCH } = await import("@/app/api/applicant/company-access/route");
+    await PATCH(createPatchRequest({ companyId: COMPANY_ID, status: "ALLOW" }));
+
+    expect(mockPrisma.companyAccess.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          userId_companyId: {
+            userId: USER_ID,
+            companyId: COMPANY_ID,
+          },
+        },
+        create: expect.objectContaining({
+          userId: USER_ID,
+          companyId: COMPANY_ID,
+          status: "ALLOW",
+        }),
+        update: { status: "ALLOW" },
+      }),
+    );
+  });
+
+  it("企業が存在しない場合404を返す", async () => {
+    mockPrisma.company.findUnique.mockResolvedValue(null);
+
+    const { PATCH } = await import("@/app/api/applicant/company-access/route");
+    const response = await PATCH(
+      createPatchRequest({ companyId: "non-existent", status: "ALLOW" }),
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it("companyIdなしで400を返す", async () => {
+    const { PATCH } = await import("@/app/api/applicant/company-access/route");
+    const response = await PATCH(createPatchRequest({ status: "ALLOW" }));
+
+    expect(response.status).toBe(400);
+  });
+
+  it("無効なステータスで400を返す", async () => {
+    const { PATCH } = await import("@/app/api/applicant/company-access/route");
+    const response = await PATCH(
+      createPatchRequest({ companyId: COMPANY_ID, status: "INVALID" }),
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("未認証の場合401を返す", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const { PATCH } = await import("@/app/api/applicant/company-access/route");
+    const response = await PATCH(
+      createPatchRequest({ companyId: COMPANY_ID, status: "ALLOW" }),
+    );
+
+    expect(response.status).toBe(401);
+  });
+});
+
+// ── DELETE Tests ────────────────────────────────────────────────────
+
+describe("DELETE /api/applicant/company-access", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(userSession);
+    mockPrisma.companyAccess.findUnique.mockResolvedValue(mockAccessRecord);
+    mockPrisma.companyAccess.delete.mockResolvedValue(mockAccessRecord);
+  });
+
+  it("アクセス設定を削除できる", async () => {
+    const { DELETE } = await import("@/app/api/applicant/company-access/route");
+    const response = await DELETE(
+      createDeleteRequest({ companyId: COMPANY_ID }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.deleted).toBe(true);
+  });
+
+  it("自分のuserIdで削除する", async () => {
+    const { DELETE } = await import("@/app/api/applicant/company-access/route");
+    await DELETE(createDeleteRequest({ companyId: COMPANY_ID }));
+
+    expect(mockPrisma.companyAccess.delete).toHaveBeenCalledWith({
+      where: {
+        userId_companyId: {
+          userId: USER_ID,
+          companyId: COMPANY_ID,
+        },
+      },
+    });
+  });
+
+  it("存在しない設定の削除は404を返す", async () => {
+    mockPrisma.companyAccess.findUnique.mockResolvedValue(null);
+
+    const { DELETE } = await import("@/app/api/applicant/company-access/route");
+    const response = await DELETE(
+      createDeleteRequest({ companyId: COMPANY_ID }),
+    );
+
+    expect(response.status).toBe(404);
+    expect(mockPrisma.companyAccess.delete).not.toHaveBeenCalled();
+  });
+
+  it("companyIdなしで400を返す", async () => {
+    const { DELETE } = await import("@/app/api/applicant/company-access/route");
+    const response = await DELETE(createDeleteRequest({}));
+
+    expect(response.status).toBe(400);
+  });
+
+  it("未認証の場合401を返す", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const { DELETE } = await import("@/app/api/applicant/company-access/route");
+    const response = await DELETE(
+      createDeleteRequest({ companyId: COMPANY_ID }),
+    );
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/src/app/api/applicant/inbox/[interestId]/approve/__tests__/approve.test.ts
+++ b/src/app/api/applicant/inbox/[interestId]/approve/__tests__/approve.test.ts
@@ -1,0 +1,333 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// NextAuth モック
+const mockGetServerSession = vi.fn();
+vi.mock("next-auth", () => ({
+  getServerSession: () => mockGetServerSession(),
+}));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+
+// Logger モック
+const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+vi.mock("@/lib/logger", () => ({ logger: mockLogger }));
+
+// Points モック
+const mockConsumePointsWithOperations = vi.fn();
+vi.mock("@/lib/points", () => ({
+  consumePointsWithOperations: (...args: unknown[]) =>
+    mockConsumePointsWithOperations(...args),
+}));
+
+// Prisma モック
+const mockPrisma = {
+  interest: { findUnique: vi.fn() },
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+const INTEREST_ID = "interest-001";
+const USER_ID = "user-001";
+const RECRUITER_ID = "recruiter-001";
+const COMPANY_ID = "company-001";
+
+const userSession = {
+  user: {
+    accountId: "acc-1",
+    userId: USER_ID,
+    accountType: "USER",
+  },
+};
+
+const routeContext = {
+  params: Promise.resolve({ interestId: INTEREST_ID }),
+};
+
+const mockInterest = {
+  id: INTEREST_ID,
+  userId: USER_ID,
+  recruiterId: RECRUITER_ID,
+  status: "CONTACT_REQUESTED",
+  user: {
+    id: USER_ID,
+    name: "テスト太郎",
+    email: "test@example.com",
+    phone: "090-1234-5678",
+    accountId: "acc-user",
+  },
+  recruiter: {
+    id: RECRUITER_ID,
+    companyId: COMPANY_ID,
+    accountId: "acc-recruiter",
+    company: { name: "テスト株式会社" },
+  },
+};
+
+function createRequest(body?: unknown): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/applicant/inbox/${INTEREST_ID}/approve`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    },
+  );
+}
+
+describe("POST /api/applicant/inbox/[interestId]/approve", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(userSession);
+    mockPrisma.interest.findUnique.mockResolvedValue(mockInterest);
+    mockConsumePointsWithOperations.mockImplementation(
+      async (
+        _companyId: string,
+        _action: string,
+        operations: (tx: unknown) => Promise<unknown>,
+      ) => {
+        const mockTx = {
+          interest: {
+            updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+          },
+          companyAccess: { upsert: vi.fn().mockResolvedValue({}) },
+          notification: { create: vi.fn().mockResolvedValue({}) },
+        };
+        const result = await operations(mockTx);
+        return { newBalance: 50, consumed: 10, result };
+      },
+    );
+  });
+
+  describe("認証", () => {
+    it("未認証の場合は401を返す", async () => {
+      mockGetServerSession.mockResolvedValue(null);
+      const { POST } = await import(
+        "@/app/api/applicant/inbox/[interestId]/approve/route"
+      );
+
+      const res = await POST(createRequest(), routeContext);
+      expect(res.status).toBe(401);
+    });
+
+    it("他人の興味表明は403を返す", async () => {
+      mockPrisma.interest.findUnique.mockResolvedValue({
+        ...mockInterest,
+        userId: "other-user",
+      });
+      const { POST } = await import(
+        "@/app/api/applicant/inbox/[interestId]/approve/route"
+      );
+
+      const res = await POST(createRequest(), routeContext);
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("状態チェック", () => {
+    it("存在しない興味表明は404を返す", async () => {
+      mockPrisma.interest.findUnique.mockResolvedValue(null);
+      const { POST } = await import(
+        "@/app/api/applicant/inbox/[interestId]/approve/route"
+      );
+
+      const res = await POST(createRequest(), routeContext);
+      expect(res.status).toBe(404);
+    });
+
+    it("既に開示済みの場合は連絡先を返す（冪等）", async () => {
+      mockPrisma.interest.findUnique.mockResolvedValue({
+        ...mockInterest,
+        status: "CONTACT_DISCLOSED",
+      });
+      const { POST } = await import(
+        "@/app/api/applicant/inbox/[interestId]/approve/route"
+      );
+
+      const res = await POST(createRequest(), routeContext);
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.status).toBe("CONTACT_DISCLOSED");
+      expect(data.contact.email).toBe("test@example.com");
+      // consumePointsは呼ばれない
+      expect(mockConsumePointsWithOperations).not.toHaveBeenCalled();
+    });
+
+    it("辞退済みの場合は409を返す", async () => {
+      mockPrisma.interest.findUnique.mockResolvedValue({
+        ...mockInterest,
+        status: "DECLINED",
+      });
+      const { POST } = await import(
+        "@/app/api/applicant/inbox/[interestId]/approve/route"
+      );
+
+      const res = await POST(createRequest(), routeContext);
+      expect(res.status).toBe(409);
+    });
+
+    it("CONTACT_REQUESTEDでない場合は400を返す", async () => {
+      mockPrisma.interest.findUnique.mockResolvedValue({
+        ...mockInterest,
+        status: "INTERESTED",
+      });
+      const { POST } = await import(
+        "@/app/api/applicant/inbox/[interestId]/approve/route"
+      );
+
+      const res = await POST(createRequest(), routeContext);
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("正常系", () => {
+    it("承認成功で連絡先を返す", async () => {
+      const { POST } = await import(
+        "@/app/api/applicant/inbox/[interestId]/approve/route"
+      );
+
+      const res = await POST(createRequest(), routeContext);
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.status).toBe("CONTACT_DISCLOSED");
+      expect(data.contact.name).toBe("テスト太郎");
+      expect(data.contact.email).toBe("test@example.com");
+    });
+
+    it("consumePointsWithOperationsに正しいパラメータを渡す", async () => {
+      const { POST } = await import(
+        "@/app/api/applicant/inbox/[interestId]/approve/route"
+      );
+
+      await POST(createRequest(), routeContext);
+
+      expect(mockConsumePointsWithOperations).toHaveBeenCalledWith(
+        COMPANY_ID,
+        "CONTACT_DISCLOSURE",
+        expect.any(Function),
+        INTEREST_ID,
+        "連絡先開示: テスト太郎",
+      );
+    });
+
+    it("bodyなしでもデフォルトpreference=NONEで動作する", async () => {
+      const { POST } = await import(
+        "@/app/api/applicant/inbox/[interestId]/approve/route"
+      );
+
+      const req = new NextRequest(
+        `http://localhost/api/applicant/inbox/${INTEREST_ID}/approve`,
+        { method: "POST" },
+      );
+      const res = await POST(req, routeContext);
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("TOCTOU防止（二重消費防止）", () => {
+    it("トランザクション内で状態をチェックし、既に処理済みなら409を返す", async () => {
+      mockConsumePointsWithOperations.mockImplementation(
+        async (
+          _companyId: string,
+          _action: string,
+          operations: (tx: unknown) => Promise<unknown>,
+        ) => {
+          const mockTx = {
+            interest: {
+              // updateManyが0件 = 既に別リクエストで処理済み
+              updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+            },
+            companyAccess: { upsert: vi.fn() },
+            notification: { create: vi.fn() },
+          };
+          return operations(mockTx);
+        },
+      );
+      const { POST } = await import(
+        "@/app/api/applicant/inbox/[interestId]/approve/route"
+      );
+
+      const res = await POST(createRequest(), routeContext);
+      expect(res.status).toBe(409);
+    });
+
+    it("トランザクション内でupdateManyを使いstatusフィルター付きで更新する", async () => {
+      let capturedTx: {
+        interest: { updateMany: ReturnType<typeof vi.fn> };
+        companyAccess: { upsert: ReturnType<typeof vi.fn> };
+        notification: { create: ReturnType<typeof vi.fn> };
+      } | null = null;
+
+      mockConsumePointsWithOperations.mockImplementation(
+        async (
+          _companyId: string,
+          _action: string,
+          operations: (tx: unknown) => Promise<unknown>,
+        ) => {
+          const mockTx = {
+            interest: {
+              updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+            },
+            companyAccess: { upsert: vi.fn().mockResolvedValue({}) },
+            notification: { create: vi.fn().mockResolvedValue({}) },
+          };
+          capturedTx = mockTx;
+          const result = await operations(mockTx);
+          return { newBalance: 50, consumed: 10, result };
+        },
+      );
+      const { POST } = await import(
+        "@/app/api/applicant/inbox/[interestId]/approve/route"
+      );
+
+      await POST(createRequest(), routeContext);
+
+      expect(capturedTx).not.toBeNull();
+      expect(capturedTx!.interest.updateMany).toHaveBeenCalledWith({
+        where: { id: INTEREST_ID, status: "CONTACT_REQUESTED" },
+        data: { status: "CONTACT_DISCLOSED" },
+      });
+    });
+  });
+
+  describe("preference=ALLOW", () => {
+    it("ALLOWの場合はcompanyAccessをupsertする", async () => {
+      let capturedTx: {
+        interest: { updateMany: ReturnType<typeof vi.fn> };
+        companyAccess: { upsert: ReturnType<typeof vi.fn> };
+        notification: { create: ReturnType<typeof vi.fn> };
+      } | null = null;
+
+      mockConsumePointsWithOperations.mockImplementation(
+        async (
+          _companyId: string,
+          _action: string,
+          operations: (tx: unknown) => Promise<unknown>,
+        ) => {
+          const mockTx = {
+            interest: {
+              updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+            },
+            companyAccess: { upsert: vi.fn().mockResolvedValue({}) },
+            notification: { create: vi.fn().mockResolvedValue({}) },
+          };
+          capturedTx = mockTx;
+          const result = await operations(mockTx);
+          return { newBalance: 50, consumed: 10, result };
+        },
+      );
+      const { POST } = await import(
+        "@/app/api/applicant/inbox/[interestId]/approve/route"
+      );
+
+      await POST(createRequest({ preference: "ALLOW" }), routeContext);
+
+      expect(capturedTx!.companyAccess.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            userId_companyId: { userId: USER_ID, companyId: COMPANY_ID },
+          },
+          create: expect.objectContaining({ status: "ALLOW" }),
+        }),
+      );
+    });
+  });
+});

--- a/src/app/api/applicant/inbox/[interestId]/decline/__tests__/decline.test.ts
+++ b/src/app/api/applicant/inbox/[interestId]/decline/__tests__/decline.test.ts
@@ -1,0 +1,254 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// NextAuth モック
+const mockGetServerSession = vi.fn();
+vi.mock("next-auth", () => ({
+  getServerSession: () => mockGetServerSession(),
+}));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+
+// Logger モック
+const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+vi.mock("@/lib/logger", () => ({ logger: mockLogger }));
+
+// Prisma トランザクション用クライアント
+const mockTxClient = {
+  interest: { updateMany: vi.fn() },
+  companyAccess: { upsert: vi.fn() },
+  notification: { create: vi.fn() },
+};
+
+// Prisma メインクライアント
+const mockPrisma = {
+  interest: { findUnique: vi.fn() },
+  $transaction: vi.fn(),
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+const INTEREST_ID = "interest-001";
+const USER_ID = "user-001";
+const RECRUITER_ID = "recruiter-001";
+const COMPANY_ID = "company-001";
+
+const userSession = {
+  user: {
+    accountId: "acc-1",
+    userId: USER_ID,
+    accountType: "USER",
+  },
+};
+
+const routeContext = {
+  params: Promise.resolve({ interestId: INTEREST_ID }),
+};
+
+const mockInterest = {
+  id: INTEREST_ID,
+  userId: USER_ID,
+  recruiterId: RECRUITER_ID,
+  status: "CONTACT_REQUESTED",
+  user: { id: USER_ID, name: "テスト太郎" },
+  recruiter: {
+    id: RECRUITER_ID,
+    companyId: COMPANY_ID,
+    accountId: "acc-recruiter",
+    company: { name: "テスト株式会社" },
+  },
+};
+
+function createRequest(body?: unknown): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/applicant/inbox/${INTEREST_ID}/decline`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    },
+  );
+}
+
+describe("POST /api/applicant/inbox/[interestId]/decline", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(userSession);
+    mockPrisma.interest.findUnique.mockResolvedValue(mockInterest);
+    mockTxClient.interest.updateMany.mockResolvedValue({ count: 1 });
+    mockTxClient.companyAccess.upsert.mockResolvedValue({});
+    mockTxClient.notification.create.mockResolvedValue({});
+    mockPrisma.$transaction.mockImplementation(
+      async (callback: (tx: typeof mockTxClient) => Promise<unknown>) => {
+        return callback(mockTxClient);
+      },
+    );
+  });
+
+  describe("認証", () => {
+    it("未認証の場合は401を返す", async () => {
+      mockGetServerSession.mockResolvedValue(null);
+      const { POST } = await import(
+        "@/app/api/applicant/inbox/[interestId]/decline/route"
+      );
+
+      const res = await POST(createRequest(), routeContext);
+      expect(res.status).toBe(401);
+    });
+
+    it("他人の興味表明は403を返す", async () => {
+      mockPrisma.interest.findUnique.mockResolvedValue({
+        ...mockInterest,
+        userId: "other-user",
+      });
+      const { POST } = await import(
+        "@/app/api/applicant/inbox/[interestId]/decline/route"
+      );
+
+      const res = await POST(createRequest(), routeContext);
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("状態チェック", () => {
+    it("存在しない興味表明は404を返す", async () => {
+      mockPrisma.interest.findUnique.mockResolvedValue(null);
+      const { POST } = await import(
+        "@/app/api/applicant/inbox/[interestId]/decline/route"
+      );
+
+      const res = await POST(createRequest(), routeContext);
+      expect(res.status).toBe(404);
+    });
+
+    it("既に開示済みの場合は409を返す", async () => {
+      mockPrisma.interest.findUnique.mockResolvedValue({
+        ...mockInterest,
+        status: "CONTACT_DISCLOSED",
+      });
+      const { POST } = await import(
+        "@/app/api/applicant/inbox/[interestId]/decline/route"
+      );
+
+      const res = await POST(createRequest(), routeContext);
+      expect(res.status).toBe(409);
+    });
+
+    it("既に辞退済みの場合は冪等にDECLINEDを返す", async () => {
+      mockPrisma.interest.findUnique.mockResolvedValue({
+        ...mockInterest,
+        status: "DECLINED",
+      });
+      const { POST } = await import(
+        "@/app/api/applicant/inbox/[interestId]/decline/route"
+      );
+
+      const res = await POST(createRequest(), routeContext);
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.status).toBe("DECLINED");
+      // トランザクションは呼ばれない
+      expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("正常系", () => {
+    it("辞退成功でDECLINEDステータスを返す", async () => {
+      const { POST } = await import(
+        "@/app/api/applicant/inbox/[interestId]/decline/route"
+      );
+
+      const res = await POST(createRequest(), routeContext);
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.status).toBe("DECLINED");
+    });
+
+    it("bodyなしでもデフォルトpreference=NONEで動作する", async () => {
+      const { POST } = await import(
+        "@/app/api/applicant/inbox/[interestId]/decline/route"
+      );
+
+      const req = new NextRequest(
+        `http://localhost/api/applicant/inbox/${INTEREST_ID}/decline`,
+        { method: "POST" },
+      );
+      const res = await POST(req, routeContext);
+      expect(res.status).toBe(200);
+      // companyAccessのupsertは呼ばれない
+      expect(mockTxClient.companyAccess.upsert).not.toHaveBeenCalled();
+    });
+
+    it("通知が作成される", async () => {
+      const { POST } = await import(
+        "@/app/api/applicant/inbox/[interestId]/decline/route"
+      );
+
+      await POST(createRequest(), routeContext);
+
+      expect(mockTxClient.notification.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          accountId: "acc-recruiter",
+          type: "SYSTEM",
+          title: "連絡先開示が辞退されました",
+        }),
+      });
+    });
+  });
+
+  describe("TOCTOU防止", () => {
+    it("トランザクション内でupdateManyを使い原子的に状態更新する", async () => {
+      const { POST } = await import(
+        "@/app/api/applicant/inbox/[interestId]/decline/route"
+      );
+
+      await POST(createRequest(), routeContext);
+
+      expect(mockTxClient.interest.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: INTEREST_ID,
+          status: { notIn: ["DECLINED", "CONTACT_DISCLOSED"] },
+        },
+        data: { status: "DECLINED" },
+      });
+    });
+
+    it("updateManyが0件の場合（同時処理済み）は409を返す", async () => {
+      mockTxClient.interest.updateMany.mockResolvedValue({ count: 0 });
+      const { POST } = await import(
+        "@/app/api/applicant/inbox/[interestId]/decline/route"
+      );
+
+      const res = await POST(createRequest(), routeContext);
+      expect(res.status).toBe(409);
+    });
+  });
+
+  describe("preference=DENY", () => {
+    it("DENYの場合はcompanyAccessにDENYをupsertする", async () => {
+      const { POST } = await import(
+        "@/app/api/applicant/inbox/[interestId]/decline/route"
+      );
+
+      await POST(createRequest({ preference: "DENY" }), routeContext);
+
+      expect(mockTxClient.companyAccess.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            userId_companyId: { userId: USER_ID, companyId: COMPANY_ID },
+          },
+          create: expect.objectContaining({ status: "DENY" }),
+          update: { status: "DENY" },
+        }),
+      );
+    });
+
+    it("NONEの場合はcompanyAccessをupsertしない", async () => {
+      const { POST } = await import(
+        "@/app/api/applicant/inbox/[interestId]/decline/route"
+      );
+
+      await POST(createRequest({ preference: "NONE" }), routeContext);
+
+      expect(mockTxClient.companyAccess.upsert).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/api/applicant/inbox/[interestId]/messages/__tests__/messages.test.ts
+++ b/src/app/api/applicant/inbox/[interestId]/messages/__tests__/messages.test.ts
@@ -1,0 +1,464 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mocks ──────────────────────────────────────────────────────────
+
+const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+vi.mock("@/lib/logger", () => ({ logger: mockLogger }));
+
+const mockGetServerSession = vi.fn();
+vi.mock("next-auth", () => ({
+  getServerSession: (...args: unknown[]) => mockGetServerSession(...args),
+}));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+
+const mockPrisma = {
+  interest: {
+    findFirst: vi.fn(),
+    updateMany: vi.fn(),
+  },
+  directMessage: {
+    findMany: vi.fn(),
+    create: vi.fn(),
+  },
+  notification: {
+    create: vi.fn(),
+  },
+  $transaction: vi.fn(),
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+// ── Constants ──────────────────────────────────────────────────────
+
+const INTEREST_ID = "interest-001";
+const USER_ID = "user-001";
+const RECRUITER_ID = "rec-001";
+const RECRUITER_ACCOUNT_ID = "acc-rec-001";
+
+const routeContext = {
+  params: Promise.resolve({ interestId: INTEREST_ID }),
+};
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function userSession() {
+  return {
+    user: {
+      accountId: "acc-user-001",
+      accountType: "USER",
+      userId: USER_ID,
+      recruiterId: null,
+    },
+  };
+}
+
+function mockInterest(overrides = {}) {
+  return {
+    id: INTEREST_ID,
+    userId: USER_ID,
+    recruiterId: RECRUITER_ID,
+    status: "CONTACT_DISCLOSED",
+    recruiter: { accountId: RECRUITER_ACCOUNT_ID },
+    user: { name: "テスト太郎" },
+    ...overrides,
+  };
+}
+
+function createGetRequest(): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/applicant/inbox/${INTEREST_ID}/messages`,
+    { method: "GET" },
+  );
+}
+
+function createPostRequest(body: unknown): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/applicant/inbox/${INTEREST_ID}/messages`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+async function importRoute() {
+  return import("@/app/api/applicant/inbox/[interestId]/messages/route");
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+describe("GET /api/applicant/inbox/[interestId]/messages", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("認証済み求職者がメッセージ一覧を取得できる", async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+    mockPrisma.interest.findFirst.mockResolvedValue(mockInterest());
+    mockPrisma.directMessage.findMany.mockResolvedValue([
+      {
+        id: "msg-1",
+        content: "こんにちは",
+        senderType: "RECRUITER",
+        createdAt: new Date("2025-01-01"),
+        recruiter: { company: { name: "テスト株式会社" } },
+        user: null,
+      },
+      {
+        id: "msg-2",
+        content: "返信します",
+        senderType: "USER",
+        createdAt: new Date("2025-01-02"),
+        recruiter: null,
+        user: { name: "テスト太郎" },
+      },
+    ]);
+
+    const { GET } = await importRoute();
+    const res = await GET(createGetRequest(), routeContext);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.messages).toHaveLength(2);
+    expect(body.messages[0].recruiter).toEqual({
+      companyName: "テスト株式会社",
+    });
+    expect(body.messages[1].user).toEqual({ name: "テスト太郎" });
+  });
+
+  it("自分宛て以外の興味表明は404を返す", async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+    mockPrisma.interest.findFirst.mockResolvedValue(null);
+
+    const { GET } = await importRoute();
+    const res = await GET(createGetRequest(), routeContext);
+    expect(res.status).toBe(404);
+  });
+
+  it("未認証の場合は401を返す", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const { GET } = await importRoute();
+    const res = await GET(createGetRequest(), routeContext);
+    expect(res.status).toBe(401);
+  });
+
+  it("findFirstでuserIdフィルタをかけている", async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+    mockPrisma.interest.findFirst.mockResolvedValue(mockInterest());
+    mockPrisma.directMessage.findMany.mockResolvedValue([]);
+
+    const { GET } = await importRoute();
+    await GET(createGetRequest(), routeContext);
+
+    expect(mockPrisma.interest.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: INTEREST_ID,
+        userId: USER_ID,
+      },
+    });
+  });
+});
+
+describe("POST /api/applicant/inbox/[interestId]/messages", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── バリデーション ──────────────────────────────────────────
+
+  describe("バリデーション", () => {
+    it("空のcontentで400を返す", async () => {
+      mockGetServerSession.mockResolvedValue(userSession());
+      mockPrisma.interest.findFirst.mockResolvedValue(mockInterest());
+
+      const { POST } = await importRoute();
+      const res = await POST(createPostRequest({ content: "" }), routeContext);
+      expect(res.status).toBe(400);
+    });
+
+    it("5000文字超のcontentで400を返す", async () => {
+      mockGetServerSession.mockResolvedValue(userSession());
+      mockPrisma.interest.findFirst.mockResolvedValue(mockInterest());
+
+      const { POST } = await importRoute();
+      const res = await POST(
+        createPostRequest({ content: "a".repeat(5001) }),
+        routeContext,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("contentが未指定で400を返す", async () => {
+      mockGetServerSession.mockResolvedValue(userSession());
+      mockPrisma.interest.findFirst.mockResolvedValue(mockInterest());
+
+      const { POST } = await importRoute();
+      const res = await POST(createPostRequest({}), routeContext);
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // ── 認証・認可 ──────────────────────────────────────────────
+
+  describe("認証・認可", () => {
+    it("未認証の場合は401を返す", async () => {
+      mockGetServerSession.mockResolvedValue(null);
+
+      const { POST } = await importRoute();
+      const res = await POST(
+        createPostRequest({ content: "hello" }),
+        routeContext,
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it("自分宛てでないまたはCONTACT_DISCLOSED以外で403を返す", async () => {
+      mockGetServerSession.mockResolvedValue(userSession());
+      mockPrisma.interest.findFirst.mockResolvedValue(null);
+
+      const { POST } = await importRoute();
+      const res = await POST(
+        createPostRequest({ content: "hello" }),
+        routeContext,
+      );
+      expect(res.status).toBe(403);
+    });
+
+    it("findFirstでuserIdとstatusフィルタをかけている", async () => {
+      mockGetServerSession.mockResolvedValue(userSession());
+      mockPrisma.interest.findFirst.mockResolvedValue(mockInterest());
+
+      const mockTxClient = {
+        interest: {
+          updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+        },
+        directMessage: {
+          create: vi.fn().mockResolvedValue({
+            id: "msg-new",
+            content: "test",
+            senderType: "USER",
+            createdAt: new Date(),
+            user: { name: "テスト太郎" },
+          }),
+        },
+        notification: { create: vi.fn().mockResolvedValue({}) },
+      };
+      mockPrisma.$transaction.mockImplementation(
+        async (callback: (tx: typeof mockTxClient) => Promise<unknown>) =>
+          callback(mockTxClient),
+      );
+
+      const { POST } = await importRoute();
+      await POST(createPostRequest({ content: "test" }), routeContext);
+
+      expect(mockPrisma.interest.findFirst).toHaveBeenCalledWith({
+        where: {
+          id: INTEREST_ID,
+          userId: USER_ID,
+          status: "CONTACT_DISCLOSED",
+        },
+        include: {
+          recruiter: { select: { accountId: true } },
+          user: { select: { name: true } },
+        },
+      });
+    });
+  });
+
+  // ── メッセージ送信 ──────────────────────────────────────────
+
+  describe("メッセージ送信", () => {
+    beforeEach(() => {
+      mockGetServerSession.mockResolvedValue(userSession());
+      mockPrisma.interest.findFirst.mockResolvedValue(mockInterest());
+    });
+
+    it("メッセージ送信成功で201を返す", async () => {
+      const createdMsg = {
+        id: "msg-new",
+        content: "ありがとうございます",
+        senderType: "USER",
+        createdAt: new Date(),
+        user: { name: "テスト太郎" },
+      };
+
+      const mockTxClient = {
+        interest: {
+          updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+        },
+        directMessage: { create: vi.fn().mockResolvedValue(createdMsg) },
+        notification: { create: vi.fn().mockResolvedValue({}) },
+      };
+      mockPrisma.$transaction.mockImplementation(
+        async (callback: (tx: typeof mockTxClient) => Promise<unknown>) =>
+          callback(mockTxClient),
+      );
+
+      const { POST } = await importRoute();
+      const res = await POST(
+        createPostRequest({ content: "ありがとうございます" }),
+        routeContext,
+      );
+      expect(res.status).toBe(201);
+
+      const body = await res.json();
+      expect(body.message.id).toBe("msg-new");
+      expect(body.message.recruiter).toBeNull();
+      expect(body.message.user).toEqual({ name: "テスト太郎" });
+    });
+
+    it("通知を採用担当者宛てに作成する", async () => {
+      const mockTxClient = {
+        interest: {
+          updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+        },
+        directMessage: {
+          create: vi.fn().mockResolvedValue({
+            id: "msg-new",
+            content: "hello",
+            senderType: "USER",
+            createdAt: new Date(),
+            user: { name: "テスト太郎" },
+          }),
+        },
+        notification: { create: vi.fn().mockResolvedValue({}) },
+      };
+      mockPrisma.$transaction.mockImplementation(
+        async (callback: (tx: typeof mockTxClient) => Promise<unknown>) =>
+          callback(mockTxClient),
+      );
+
+      const { POST } = await importRoute();
+      await POST(createPostRequest({ content: "hello" }), routeContext);
+
+      expect(mockTxClient.notification.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          accountId: RECRUITER_ACCOUNT_ID,
+          type: "SYSTEM",
+          title: "新しいメッセージ",
+          body: "テスト太郎からメッセージが届きました",
+        }),
+      });
+    });
+
+    it("contentの前後空白がトリムされる", async () => {
+      const mockTxClient = {
+        interest: {
+          updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+        },
+        directMessage: {
+          create: vi.fn().mockResolvedValue({
+            id: "msg-new",
+            content: "trimmed",
+            senderType: "USER",
+            createdAt: new Date(),
+            user: { name: "テスト太郎" },
+          }),
+        },
+        notification: { create: vi.fn().mockResolvedValue({}) },
+      };
+      mockPrisma.$transaction.mockImplementation(
+        async (callback: (tx: typeof mockTxClient) => Promise<unknown>) =>
+          callback(mockTxClient),
+      );
+
+      const { POST } = await importRoute();
+      await POST(createPostRequest({ content: "  trimmed  " }), routeContext);
+
+      expect(mockTxClient.directMessage.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ content: "trimmed" }),
+        include: expect.any(Object),
+      });
+    });
+  });
+
+  // ── TOCTOU防止 ──────────────────────────────────────────────
+
+  describe("TOCTOU防止（ステータス競合）", () => {
+    beforeEach(() => {
+      mockGetServerSession.mockResolvedValue(userSession());
+      mockPrisma.interest.findFirst.mockResolvedValue(mockInterest());
+    });
+
+    it("トランザクション内でステータスが変更されていたら409を返す", async () => {
+      const mockTxClient = {
+        interest: {
+          updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+        },
+        directMessage: { create: vi.fn() },
+        notification: { create: vi.fn() },
+      };
+      mockPrisma.$transaction.mockImplementation(
+        async (callback: (tx: typeof mockTxClient) => Promise<unknown>) =>
+          callback(mockTxClient),
+      );
+
+      const { POST } = await importRoute();
+      const res = await POST(
+        createPostRequest({ content: "hello" }),
+        routeContext,
+      );
+      expect(res.status).toBe(409);
+
+      const body = await res.json();
+      expect(body.error).toContain("開示状態が変更");
+    });
+
+    it("ステータスチェック失敗後にメッセージが作成されない", async () => {
+      let msgCreateCalled = false;
+      const mockTxClient = {
+        interest: {
+          updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+        },
+        directMessage: {
+          create: vi.fn().mockImplementation(() => {
+            msgCreateCalled = true;
+            return { id: "msg-new" };
+          }),
+        },
+        notification: { create: vi.fn() },
+      };
+      mockPrisma.$transaction.mockImplementation(
+        async (callback: (tx: typeof mockTxClient) => Promise<unknown>) =>
+          callback(mockTxClient),
+      );
+
+      const { POST } = await importRoute();
+      await POST(createPostRequest({ content: "hello" }), routeContext);
+
+      expect(msgCreateCalled).toBe(false);
+    });
+
+    it("updateManyにCONTACT_DISCLOSED条件が含まれている", async () => {
+      const mockTxClient = {
+        interest: {
+          updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+        },
+        directMessage: {
+          create: vi.fn().mockResolvedValue({
+            id: "msg-new",
+            content: "test",
+            senderType: "USER",
+            createdAt: new Date(),
+            user: { name: "テスト太郎" },
+          }),
+        },
+        notification: { create: vi.fn().mockResolvedValue({}) },
+      };
+      mockPrisma.$transaction.mockImplementation(
+        async (callback: (tx: typeof mockTxClient) => Promise<unknown>) =>
+          callback(mockTxClient),
+      );
+
+      const { POST } = await importRoute();
+      await POST(createPostRequest({ content: "test" }), routeContext);
+
+      expect(mockTxClient.interest.updateMany).toHaveBeenCalledWith({
+        where: { id: INTEREST_ID, status: "CONTACT_DISCLOSED" },
+        data: { updatedAt: expect.any(Date) },
+      });
+    });
+  });
+});

--- a/src/app/api/applicant/notifications/__tests__/notifications.test.ts
+++ b/src/app/api/applicant/notifications/__tests__/notifications.test.ts
@@ -1,0 +1,317 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mocks ──────────────────────────────────────────────────────────
+
+const mockGetServerSession = vi.fn();
+vi.mock("next-auth", () => ({
+  getServerSession: () => mockGetServerSession(),
+}));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+
+const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+vi.mock("@/lib/logger", () => ({ logger: mockLogger }));
+
+const mockPrisma = {
+  notification: {
+    findMany: vi.fn(),
+    updateMany: vi.fn(),
+  },
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+// ── Constants ──────────────────────────────────────────────────────
+
+const USER_ID = "user-001";
+const ACCOUNT_ID = "acc-001";
+
+const userSession = {
+  user: {
+    userId: USER_ID,
+    accountId: ACCOUNT_ID,
+    accountType: "USER",
+  },
+};
+
+const mockNotification = {
+  id: "notif-001",
+  accountId: ACCOUNT_ID,
+  type: "INTEREST_RECEIVED",
+  title: "興味表明を受信",
+  body: "企業Aから興味表明がありました",
+  isRead: false,
+  createdAt: new Date("2024-01-15"),
+  data: { interestId: "interest-123", companyName: "企業A" },
+};
+
+const mockReadNotification = {
+  id: "notif-002",
+  accountId: ACCOUNT_ID,
+  type: "SYSTEM",
+  title: "お知らせ",
+  body: "システムメンテナンスのお知らせ",
+  isRead: true,
+  createdAt: new Date("2024-01-10"),
+  data: null,
+};
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function createGetRequest(queryString = ""): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/applicant/notifications${queryString}`,
+    { method: "GET" },
+  );
+}
+
+function createPatchRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/applicant/notifications", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// ── GET Tests ──────────────────────────────────────────────────────
+
+describe("GET /api/applicant/notifications", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(userSession);
+  });
+
+  it("通知一覧を返す", async () => {
+    mockPrisma.notification.findMany.mockResolvedValue([
+      mockNotification,
+      mockReadNotification,
+    ]);
+
+    const { GET } = await import("@/app/api/applicant/notifications/route");
+    const response = await GET(createGetRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.notifications).toHaveLength(2);
+    expect(data.unreadCount).toBe(1);
+  });
+
+  it("通知データを正しい形式に整形する", async () => {
+    mockPrisma.notification.findMany.mockResolvedValue([mockNotification]);
+
+    const { GET } = await import("@/app/api/applicant/notifications/route");
+    const response = await GET(createGetRequest());
+    const data = await response.json();
+
+    const notif = data.notifications[0];
+    expect(notif.id).toBe("notif-001");
+    expect(notif.type).toBe("INTEREST_RECEIVED");
+    expect(notif.title).toBe("興味表明を受信");
+    expect(notif.message).toBe("企業Aから興味表明がありました");
+    expect(notif.isRead).toBe(false);
+    expect(notif.relatedInterest).toEqual({
+      id: "interest-123",
+      companyName: "企業A",
+    });
+  });
+
+  it("data.interestIdがない通知はrelatedInterestがnull", async () => {
+    mockPrisma.notification.findMany.mockResolvedValue([mockReadNotification]);
+
+    const { GET } = await import("@/app/api/applicant/notifications/route");
+    const response = await GET(createGetRequest());
+    const data = await response.json();
+
+    expect(data.notifications[0].relatedInterest).toBeNull();
+  });
+
+  it("unreadOnlyパラメータでフィルタする", async () => {
+    mockPrisma.notification.findMany.mockResolvedValue([]);
+
+    const { GET } = await import("@/app/api/applicant/notifications/route");
+    await GET(createGetRequest("?unreadOnly=true"));
+
+    expect(mockPrisma.notification.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          accountId: ACCOUNT_ID,
+          isRead: false,
+        }),
+      }),
+    );
+  });
+
+  it("unreadOnly未指定時はフィルタなし", async () => {
+    mockPrisma.notification.findMany.mockResolvedValue([]);
+
+    const { GET } = await import("@/app/api/applicant/notifications/route");
+    await GET(createGetRequest());
+
+    const callArgs = mockPrisma.notification.findMany.mock.calls[0][0];
+    expect(callArgs.where.isRead).toBeUndefined();
+  });
+
+  it("未読→既読の順、作成日の降順でソートする", async () => {
+    mockPrisma.notification.findMany.mockResolvedValue([]);
+
+    const { GET } = await import("@/app/api/applicant/notifications/route");
+    await GET(createGetRequest());
+
+    expect(mockPrisma.notification.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: [{ isRead: "asc" }, { createdAt: "desc" }],
+        take: 50,
+      }),
+    );
+  });
+
+  it("空の通知リストを返す", async () => {
+    mockPrisma.notification.findMany.mockResolvedValue([]);
+
+    const { GET } = await import("@/app/api/applicant/notifications/route");
+    const response = await GET(createGetRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.notifications).toEqual([]);
+    expect(data.unreadCount).toBe(0);
+  });
+
+  it("未認証の場合401を返す", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const { GET } = await import("@/app/api/applicant/notifications/route");
+    const response = await GET(createGetRequest());
+
+    expect(response.status).toBe(401);
+  });
+
+  it("userIdがない場合403を返す", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { accountId: ACCOUNT_ID, accountType: "RECRUITER" },
+    });
+
+    const { GET } = await import("@/app/api/applicant/notifications/route");
+    const response = await GET(createGetRequest());
+
+    expect(response.status).toBe(403);
+  });
+});
+
+// ── PATCH Tests ────────────────────────────────────────────────────
+
+describe("PATCH /api/applicant/notifications", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(userSession);
+    mockPrisma.notification.updateMany.mockResolvedValue({ count: 1 });
+  });
+
+  it("markAllAsReadで全通知を既読にする", async () => {
+    const { PATCH } = await import("@/app/api/applicant/notifications/route");
+    const response = await PATCH(createPatchRequest({ markAllAsRead: true }));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(mockPrisma.notification.updateMany).toHaveBeenCalledWith({
+      where: {
+        accountId: ACCOUNT_ID,
+        isRead: false,
+      },
+      data: { isRead: true },
+    });
+  });
+
+  it("notificationIdsで個別の通知を既読にする", async () => {
+    const { PATCH } = await import("@/app/api/applicant/notifications/route");
+    const response = await PATCH(
+      createPatchRequest({ notificationIds: ["notif-001", "notif-002"] }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(mockPrisma.notification.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: ["notif-001", "notif-002"] },
+        accountId: ACCOUNT_ID,
+      },
+      data: { isRead: true },
+    });
+  });
+
+  it("interest-プレフィックスのIDをフィルタする", async () => {
+    const { PATCH } = await import("@/app/api/applicant/notifications/route");
+    await PATCH(
+      createPatchRequest({
+        notificationIds: [
+          "notif-001",
+          "interest-abc",
+          "interest-def",
+          "notif-002",
+        ],
+      }),
+    );
+
+    expect(mockPrisma.notification.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: ["notif-001", "notif-002"] },
+        accountId: ACCOUNT_ID,
+      },
+      data: { isRead: true },
+    });
+  });
+
+  it("全てinterest-プレフィックスの場合はupdateManyを呼ばない", async () => {
+    const { PATCH } = await import("@/app/api/applicant/notifications/route");
+    const response = await PATCH(
+      createPatchRequest({
+        notificationIds: ["interest-abc", "interest-def"],
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockPrisma.notification.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("accountIdでスコープする（他ユーザーの通知を更新しない）", async () => {
+    const { PATCH } = await import("@/app/api/applicant/notifications/route");
+    await PATCH(createPatchRequest({ notificationIds: ["notif-001"] }));
+
+    expect(mockPrisma.notification.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          accountId: ACCOUNT_ID,
+        }),
+      }),
+    );
+  });
+
+  it("空のリクエストボディでも200を返す", async () => {
+    const { PATCH } = await import("@/app/api/applicant/notifications/route");
+    const response = await PATCH(createPatchRequest({}));
+
+    expect(response.status).toBe(200);
+    expect(mockPrisma.notification.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("未認証の場合401を返す", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const { PATCH } = await import("@/app/api/applicant/notifications/route");
+    const response = await PATCH(createPatchRequest({ markAllAsRead: true }));
+
+    expect(response.status).toBe(401);
+  });
+
+  it("userIdがない場合403を返す", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { accountId: ACCOUNT_ID, accountType: "RECRUITER" },
+    });
+
+    const { PATCH } = await import("@/app/api/applicant/notifications/route");
+    const response = await PATCH(createPatchRequest({ markAllAsRead: true }));
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/src/app/api/applicant/settings/route.ts
+++ b/src/app/api/applicant/settings/route.ts
@@ -34,15 +34,17 @@ export const GET = withUserAuth(async (req, session) => {
 });
 
 const updateSettingsSchema = z.object({
-  name: z.string().min(1, "名前を入力してください").optional(),
+  name: z.string().min(1, "名前を入力してください").max(100).optional(),
   email: z
     .string()
     .email("メールアドレスの形式が不正です")
+    .max(254)
     .optional()
     .nullable()
     .or(z.literal("")),
   phone: z
     .string()
+    .max(30)
     .regex(/^[\d\-+().\s]*$/, "電話番号の形式が不正です")
     .optional()
     .nullable()

--- a/src/app/api/auth/passkey/[passkeyId]/__tests__/passkey-delete.test.ts
+++ b/src/app/api/auth/passkey/[passkeyId]/__tests__/passkey-delete.test.ts
@@ -1,0 +1,159 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mocks ──────────────────────────────────────────────────────────
+
+const mockGetServerSession = vi.fn();
+vi.mock("next-auth", () => ({
+  getServerSession: () => mockGetServerSession(),
+}));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+
+const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+vi.mock("@/lib/logger", () => ({ logger: mockLogger }));
+
+const mockPrisma = {
+  passkey: {
+    findUnique: vi.fn(),
+    deleteMany: vi.fn(),
+  },
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+// ── Constants ──────────────────────────────────────────────────────
+
+const ACCOUNT_ID = "acc-001";
+const PASSKEY_ID = "550e8400-e29b-41d4-a716-446655440000"; // valid UUID
+const OTHER_ACCOUNT_ID = "acc-999";
+
+const authenticatedSession = {
+  user: {
+    accountId: ACCOUNT_ID,
+    accountType: "USER",
+  },
+};
+
+const mockPasskey = {
+  id: PASSKEY_ID,
+  accountId: ACCOUNT_ID,
+  credentialId: "cred-123",
+  publicKey: Buffer.from("key"),
+  counter: 0,
+  transports: ["usb"],
+  deviceName: "YubiKey",
+  createdAt: new Date(),
+};
+
+const routeContext = {
+  params: Promise.resolve({ passkeyId: PASSKEY_ID }),
+};
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function createDeleteRequest(): NextRequest {
+  return new NextRequest(`http://localhost/api/auth/passkey/${PASSKEY_ID}`, {
+    method: "DELETE",
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+describe("DELETE /api/auth/passkey/[passkeyId]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(authenticatedSession);
+    mockPrisma.passkey.findUnique.mockResolvedValue(mockPasskey);
+    mockPrisma.passkey.deleteMany.mockResolvedValue({ count: 1 });
+  });
+
+  it("自分のパスキーを削除できる", async () => {
+    const { DELETE } = await import("@/app/api/auth/passkey/[passkeyId]/route");
+    const response = await DELETE(createDeleteRequest(), routeContext);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.deleted).toBe(true);
+  });
+
+  it("accountId条件付きdeleteMany で所有権を検証する（TOCTOU防止）", async () => {
+    const { DELETE } = await import("@/app/api/auth/passkey/[passkeyId]/route");
+    await DELETE(createDeleteRequest(), routeContext);
+
+    expect(mockPrisma.passkey.deleteMany).toHaveBeenCalledWith({
+      where: { id: PASSKEY_ID, accountId: ACCOUNT_ID },
+    });
+  });
+
+  it("同時リクエストで既に削除済みなら404を返す", async () => {
+    mockPrisma.passkey.deleteMany.mockResolvedValue({ count: 0 });
+
+    const { DELETE } = await import("@/app/api/auth/passkey/[passkeyId]/route");
+    const response = await DELETE(createDeleteRequest(), routeContext);
+
+    expect(response.status).toBe(404);
+  });
+
+  it("存在しないパスキーは404を返す", async () => {
+    mockPrisma.passkey.findUnique.mockResolvedValue(null);
+
+    const { DELETE } = await import("@/app/api/auth/passkey/[passkeyId]/route");
+    const response = await DELETE(createDeleteRequest(), routeContext);
+
+    expect(response.status).toBe(404);
+    expect(mockPrisma.passkey.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("他ユーザーのパスキーは403を返す", async () => {
+    mockPrisma.passkey.findUnique.mockResolvedValue({
+      ...mockPasskey,
+      accountId: OTHER_ACCOUNT_ID,
+    });
+
+    const { DELETE } = await import("@/app/api/auth/passkey/[passkeyId]/route");
+    const response = await DELETE(createDeleteRequest(), routeContext);
+
+    expect(response.status).toBe(403);
+    expect(mockPrisma.passkey.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("未認証の場合401を返す", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const { DELETE } = await import("@/app/api/auth/passkey/[passkeyId]/route");
+    const response = await DELETE(createDeleteRequest(), routeContext);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("accountIdがない場合401を返す", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { accountType: "USER" },
+    });
+
+    const { DELETE } = await import("@/app/api/auth/passkey/[passkeyId]/route");
+    const response = await DELETE(createDeleteRequest(), routeContext);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("無効なUUID形式の場合400を返す", async () => {
+    const invalidContext = {
+      params: Promise.resolve({ passkeyId: "not-a-uuid" }),
+    };
+
+    const { DELETE } = await import("@/app/api/auth/passkey/[passkeyId]/route");
+    const response = await DELETE(createDeleteRequest(), invalidContext);
+
+    expect(response.status).toBe(400);
+    expect(mockPrisma.passkey.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("正しいIDでfindUniqueを呼ぶ", async () => {
+    const { DELETE } = await import("@/app/api/auth/passkey/[passkeyId]/route");
+    await DELETE(createDeleteRequest(), routeContext);
+
+    expect(mockPrisma.passkey.findUnique).toHaveBeenCalledWith({
+      where: { id: PASSKEY_ID },
+    });
+  });
+});

--- a/src/app/api/auth/passkey/__tests__/passkey.test.ts
+++ b/src/app/api/auth/passkey/__tests__/passkey.test.ts
@@ -44,6 +44,7 @@ const mockPrisma = {
     findUnique: vi.fn(),
     create: vi.fn(),
     delete: vi.fn(),
+    deleteMany: vi.fn(),
     update: vi.fn(),
   },
   webAuthnChallenge: {
@@ -182,7 +183,7 @@ describe("パスキーAPI - 結合テスト", () => {
           id: "00000000-0000-4000-8000-000000000001",
           accountId: "account-1",
         });
-        mockPrisma.passkey.delete.mockResolvedValue({});
+        mockPrisma.passkey.deleteMany.mockResolvedValue({ count: 1 });
 
         const { DELETE } = await import("../[passkeyId]/route");
         const request = new NextRequest(

--- a/src/app/api/auth/passkey/register/options/route.ts
+++ b/src/app/api/auth/passkey/register/options/route.ts
@@ -3,6 +3,7 @@ import { isoBase64URL } from "@simplewebauthn/server/helpers";
 import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/api-utils";
 import { ConflictError, UnauthorizedError } from "@/lib/errors";
+import { logger } from "@/lib/logger";
 import { prisma } from "@/lib/prisma";
 import {
   buildSetCookieHeader,
@@ -35,7 +36,11 @@ export const POST = withAuth(async (_req, session) => {
     .deleteMany({
       where: { expiresAt: { lt: new Date() } },
     })
-    .catch(() => {});
+    .catch((err) => {
+      logger.warn("Failed to cleanup expired WebAuthn challenges", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
 
   // webauthnUserId がなければ生成してAccountに保存
   let webauthnUserId = account.webauthnUserId;

--- a/src/app/api/auth/register/__tests__/register.test.ts
+++ b/src/app/api/auth/register/__tests__/register.test.ts
@@ -1,0 +1,425 @@
+import { Prisma } from "@prisma/client";
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Rate limiter モック（テスト時はレート制限をスキップ）
+vi.mock("@/lib/rate-limiter", () => ({
+  RATE_LIMIT_PRESETS: {
+    PUBLIC_AUTH: { points: 10, duration: 60 },
+    REGISTER: { points: 5, duration: 300 },
+    VERIFY_EMAIL: { points: 3, duration: 300 },
+  },
+  checkRateLimit: vi.fn(),
+}));
+
+// bcryptjs モック
+const mockHash = vi.fn();
+vi.mock("bcryptjs", () => ({
+  hash: (...args: unknown[]) => mockHash(...args),
+}));
+
+// Logger モック
+const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+vi.mock("@/lib/logger", () => ({ logger: mockLogger }));
+
+// Prisma トランザクション用クライアント
+const mockTxClient = {
+  account: { create: vi.fn() },
+  company: { create: vi.fn() },
+  recruiter: { create: vi.fn() },
+};
+
+// Prisma メインクライアント
+const mockPrisma = {
+  account: { findUnique: vi.fn(), create: vi.fn() },
+  $transaction: vi.fn(),
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+// Company モック
+const mockGenerateUniqueSlug = vi.fn();
+vi.mock("@/lib/company", () => ({
+  generateUniqueSlug: (...args: unknown[]) => mockGenerateUniqueSlug(...args),
+}));
+
+// Verification モック
+const mockCreateAndSendVerificationToken = vi.fn();
+vi.mock("@/lib/verification", () => ({
+  createAndSendVerificationToken: (...args: unknown[]) =>
+    mockCreateAndSendVerificationToken(...args),
+}));
+
+// NextAuth モック
+vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+
+function createRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/auth/register", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const validUserBody = {
+  email: "test@example.com",
+  password: "password123",
+  name: "テスト太郎",
+  accountType: "USER" as const,
+};
+
+const validRecruiterBody = {
+  email: "recruiter@example.com",
+  password: "password123",
+  name: "採用太郎",
+  accountType: "RECRUITER" as const,
+  companyName: "テスト株式会社",
+};
+
+describe("POST /api/auth/register", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHash.mockResolvedValue("hashed_password");
+    mockPrisma.account.findUnique.mockResolvedValue(null);
+    mockGenerateUniqueSlug.mockResolvedValue("test-company");
+    mockCreateAndSendVerificationToken.mockResolvedValue(undefined);
+    mockPrisma.$transaction.mockImplementation(
+      async (callback: (tx: typeof mockTxClient) => Promise<unknown>) => {
+        return callback(mockTxClient);
+      },
+    );
+  });
+
+  describe("バリデーション", () => {
+    it("メールアドレスが無効な場合は400を返す", async () => {
+      const { POST } = await import("@/app/api/auth/register/route");
+      const req = createRequest({ ...validUserBody, email: "not-an-email" });
+
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+    });
+
+    it("パスワードが6文字未満の場合は400を返す", async () => {
+      const { POST } = await import("@/app/api/auth/register/route");
+      const req = createRequest({ ...validUserBody, password: "12345" });
+
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+    });
+
+    it("パスワードが100文字を超える場合は400を返す", async () => {
+      const { POST } = await import("@/app/api/auth/register/route");
+      const req = createRequest({
+        ...validUserBody,
+        password: "a".repeat(101),
+      });
+
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+    });
+
+    it("名前が空の場合は400を返す", async () => {
+      const { POST } = await import("@/app/api/auth/register/route");
+      const req = createRequest({ ...validUserBody, name: "" });
+
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+    });
+
+    it("無効なaccountTypeの場合は400を返す", async () => {
+      const { POST } = await import("@/app/api/auth/register/route");
+      const req = createRequest({
+        ...validUserBody,
+        accountType: "INVALID",
+      });
+
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+    });
+
+    it("RECRUITER登録時にcompanyNameが空の場合は400を返す", async () => {
+      const { POST } = await import("@/app/api/auth/register/route");
+      const req = createRequest({
+        ...validRecruiterBody,
+        companyName: "",
+      });
+
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+    });
+
+    it("RECRUITER登録時にcompanyNameがない場合は400を返す", async () => {
+      const { POST } = await import("@/app/api/auth/register/route");
+      const { companyName: _, ...body } = validRecruiterBody;
+      const req = createRequest(body);
+
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("求職者（USER）登録", () => {
+    it("正常に登録でき201を返す", async () => {
+      const { POST } = await import("@/app/api/auth/register/route");
+      mockPrisma.account.create.mockResolvedValue({
+        id: "acc-1",
+        email: "test@example.com",
+        accountType: "USER",
+        user: { id: "user-1", name: "テスト太郎" },
+      });
+
+      const req = createRequest(validUserBody);
+      const res = await POST(req);
+
+      expect(res.status).toBe(201);
+      const data = await res.json();
+      expect(data.account.id).toBe("acc-1");
+      expect(data.account.email).toBe("test@example.com");
+      expect(data.account.accountType).toBe("USER");
+      expect(data.requiresVerification).toBe(true);
+    });
+
+    it("パスワードをbcryptでハッシュ化する", async () => {
+      const { POST } = await import("@/app/api/auth/register/route");
+      mockPrisma.account.create.mockResolvedValue({
+        id: "acc-1",
+        email: "test@example.com",
+        accountType: "USER",
+      });
+
+      const req = createRequest(validUserBody);
+      await POST(req);
+
+      expect(mockHash).toHaveBeenCalledWith("password123", 12);
+      expect(mockPrisma.account.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ passwordHash: "hashed_password" }),
+        }),
+      );
+    });
+
+    it("アカウント作成後に認証メールを送信する", async () => {
+      const { POST } = await import("@/app/api/auth/register/route");
+      mockPrisma.account.create.mockResolvedValue({
+        id: "acc-1",
+        email: "test@example.com",
+        accountType: "USER",
+      });
+
+      const req = createRequest(validUserBody);
+      await POST(req);
+
+      expect(mockCreateAndSendVerificationToken).toHaveBeenCalledWith(
+        "acc-1",
+        "test@example.com",
+      );
+    });
+
+    it("認証メール送信が失敗してもアカウント登録は成功する", async () => {
+      const { POST } = await import("@/app/api/auth/register/route");
+      mockPrisma.account.create.mockResolvedValue({
+        id: "acc-1",
+        email: "test@example.com",
+        accountType: "USER",
+      });
+      mockCreateAndSendVerificationToken.mockRejectedValue(
+        new Error("SMTP connection failed"),
+      );
+
+      const req = createRequest(validUserBody);
+      const res = await POST(req);
+
+      expect(res.status).toBe(201);
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "Failed to send verification email after registration",
+        expect.any(Error),
+        expect.objectContaining({ accountId: "acc-1" }),
+      );
+    });
+  });
+
+  describe("採用担当者（RECRUITER）登録", () => {
+    it("正常に登録でき201を返す（会社+Recruiter同時作成）", async () => {
+      const { POST } = await import("@/app/api/auth/register/route");
+      mockTxClient.account.create.mockResolvedValue({
+        id: "acc-2",
+        email: "recruiter@example.com",
+        accountType: "RECRUITER",
+      });
+      mockTxClient.company.create.mockResolvedValue({
+        id: "comp-1",
+        name: "テスト株式会社",
+        slug: "test-company",
+      });
+      mockTxClient.recruiter.create.mockResolvedValue({
+        id: "rec-1",
+        role: "OWNER",
+      });
+
+      const req = createRequest(validRecruiterBody);
+      const res = await POST(req);
+
+      expect(res.status).toBe(201);
+      const data = await res.json();
+      expect(data.account.accountType).toBe("RECRUITER");
+      expect(data.company.name).toBe("テスト株式会社");
+      expect(data.company.slug).toBe("test-company");
+      expect(data.recruiter.role).toBe("OWNER");
+      expect(data.requiresVerification).toBe(true);
+    });
+
+    it("トランザクション内でアカウント→会社→Recruiterの順に作成する", async () => {
+      const { POST } = await import("@/app/api/auth/register/route");
+      const callOrder: string[] = [];
+      mockTxClient.account.create.mockImplementation(async () => {
+        callOrder.push("account");
+        return {
+          id: "acc-2",
+          email: "recruiter@example.com",
+          accountType: "RECRUITER",
+        };
+      });
+      mockTxClient.company.create.mockImplementation(async () => {
+        callOrder.push("company");
+        return { id: "comp-1", name: "テスト株式会社", slug: "test-company" };
+      });
+      mockTxClient.recruiter.create.mockImplementation(async () => {
+        callOrder.push("recruiter");
+        return { id: "rec-1", role: "OWNER" };
+      });
+
+      const req = createRequest(validRecruiterBody);
+      await POST(req);
+
+      expect(callOrder).toEqual(["account", "company", "recruiter"]);
+      expect(mockPrisma.$transaction).toHaveBeenCalled();
+    });
+
+    it("会社スラッグを生成する", async () => {
+      const { POST } = await import("@/app/api/auth/register/route");
+      mockTxClient.account.create.mockResolvedValue({
+        id: "acc-2",
+        email: "recruiter@example.com",
+        accountType: "RECRUITER",
+      });
+      mockTxClient.company.create.mockResolvedValue({
+        id: "comp-1",
+        name: "テスト株式会社",
+        slug: "test-company",
+      });
+      mockTxClient.recruiter.create.mockResolvedValue({
+        id: "rec-1",
+        role: "OWNER",
+      });
+
+      const req = createRequest(validRecruiterBody);
+      await POST(req);
+
+      expect(mockGenerateUniqueSlug).toHaveBeenCalledWith("テスト株式会社");
+    });
+
+    it("認証メール送信が失敗しても登録は成功する", async () => {
+      const { POST } = await import("@/app/api/auth/register/route");
+      mockTxClient.account.create.mockResolvedValue({
+        id: "acc-2",
+        email: "recruiter@example.com",
+        accountType: "RECRUITER",
+      });
+      mockTxClient.company.create.mockResolvedValue({
+        id: "comp-1",
+        name: "テスト株式会社",
+        slug: "test-company",
+      });
+      mockTxClient.recruiter.create.mockResolvedValue({
+        id: "rec-1",
+        role: "OWNER",
+      });
+      mockCreateAndSendVerificationToken.mockRejectedValue(
+        new Error("Email service down"),
+      );
+
+      const req = createRequest(validRecruiterBody);
+      const res = await POST(req);
+
+      expect(res.status).toBe(201);
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "Failed to send verification email after registration",
+        expect.any(Error),
+        expect.objectContaining({ accountId: "acc-2" }),
+      );
+    });
+  });
+
+  describe("メールアドレス重複チェック", () => {
+    it("既存アカウントがある場合は409を返す", async () => {
+      const { POST } = await import("@/app/api/auth/register/route");
+      mockPrisma.account.findUnique.mockResolvedValue({
+        id: "existing-acc",
+        email: "test@example.com",
+      });
+
+      const req = createRequest(validUserBody);
+      const res = await POST(req);
+
+      expect(res.status).toBe(409);
+      const data = await res.json();
+      expect(data.error).toContain("既に登録されています");
+    });
+
+    it("レースコンディション: DB unique制約違反時は409を返す（USER）", async () => {
+      const { POST } = await import("@/app/api/auth/register/route");
+      // findUniqueは通過するが、createでunique制約違反
+      mockPrisma.account.create.mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+          code: "P2002",
+          clientVersion: "6.0.0",
+        }),
+      );
+
+      const req = createRequest(validUserBody);
+      const res = await POST(req);
+
+      expect(res.status).toBe(409);
+      const data = await res.json();
+      expect(data.error).toContain("既に登録されています");
+    });
+
+    it("レースコンディション: DB unique制約違反時は409を返す（RECRUITER）", async () => {
+      const { POST } = await import("@/app/api/auth/register/route");
+      // トランザクション内でunique制約違反
+      mockPrisma.$transaction.mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+          code: "P2002",
+          clientVersion: "6.0.0",
+        }),
+      );
+
+      mockTxClient.account.create.mockResolvedValue({
+        id: "acc-2",
+        email: "recruiter@example.com",
+        accountType: "RECRUITER",
+      });
+
+      const req = createRequest(validRecruiterBody);
+      const res = await POST(req);
+
+      expect(res.status).toBe(409);
+    });
+
+    it("P2002以外のPrismaエラーは再スローされる", async () => {
+      const { POST } = await import("@/app/api/auth/register/route");
+      mockPrisma.account.create.mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError("Connection error", {
+          code: "P1001",
+          clientVersion: "6.0.0",
+        }),
+      );
+
+      const req = createRequest(validUserBody);
+      const res = await POST(req);
+
+      // withErrorHandlingが500を返す
+      expect(res.status).toBe(500);
+    });
+  });
+});

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -1,22 +1,28 @@
 import type { AccountType } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 import { hash } from "bcryptjs";
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { withValidation } from "@/lib/api-utils";
+import { withRateLimitValidation } from "@/lib/api-utils";
 import { generateUniqueSlug } from "@/lib/company";
 import { ConflictError } from "@/lib/errors";
+import { logger } from "@/lib/logger";
 import { prisma } from "@/lib/prisma";
+import { RATE_LIMIT_PRESETS } from "@/lib/rate-limiter";
 import { createAndSendVerificationToken } from "@/lib/verification";
 
 const registerSchema = z
   .object({
     email: z.string().email("有効なメールアドレスを入力してください"),
-    password: z.string().min(6, "パスワードは6文字以上で入力してください"),
-    name: z.string().min(1, "名前は必須です"),
+    password: z
+      .string()
+      .min(6, "パスワードは6文字以上で入力してください")
+      .max(100, "パスワードは100文字以下で入力してください"),
+    name: z.string().min(1, "名前は必須です").max(100),
     accountType: z.enum(["USER", "RECRUITER"], {
       message: "アカウントタイプはUSERまたはRECRUITERを指定してください",
     }),
-    companyName: z.string().optional(),
+    companyName: z.string().max(200).optional(),
   })
   .refine(
     (data) => {
@@ -31,82 +37,138 @@ const registerSchema = z
     },
   );
 
-export const POST = withValidation(registerSchema, async (body, req) => {
-  const { email, password, name, accountType, companyName } = body;
+/**
+ * Prismaのユニーク制約違反を判定
+ */
+function isUniqueConstraintError(error: unknown): boolean {
+  return (
+    error instanceof Prisma.PrismaClientKnownRequestError &&
+    error.code === "P2002"
+  );
+}
 
-  const existingAccount = await prisma.account.findUnique({
-    where: { email },
-  });
-
-  if (existingAccount) {
-    throw new ConflictError("このメールアドレスは既に登録されています");
-  }
-
-  const passwordHash = await hash(password, 12);
-
-  if (accountType === "RECRUITER") {
-    // 採用担当者 + 会社を同時作成
-    const validatedCompanyName = companyName as string;
-    const slug = await generateUniqueSlug(validatedCompanyName);
-
-    const result = await prisma.$transaction(async (tx) => {
-      // アカウント作成
-      const account = await tx.account.create({
-        data: {
-          email,
-          passwordHash,
-          accountType: accountType as AccountType,
-        },
-      });
-
-      // 会社作成
-      const company = await tx.company.create({
-        data: {
-          name: validatedCompanyName,
-          slug,
-          createdByAccountId: account.id,
-        },
-      });
-
-      // Recruiter作成（OWNERとして）
-      const recruiter = await tx.recruiter.create({
-        data: {
-          accountId: account.id,
-          companyId: company.id,
-          role: "OWNER",
-          status: "ACTIVE",
-          joinedAt: new Date(),
-        },
-      });
-
-      return { account, company, recruiter };
-    });
-
-    await createAndSendVerificationToken(result.account.id, email);
-
-    return NextResponse.json(
-      {
-        account: {
-          id: result.account.id,
-          email: result.account.email,
-          accountType: result.account.accountType,
-        },
-        company: {
-          id: result.company.id,
-          name: result.company.name,
-          slug: result.company.slug,
-        },
-        recruiter: {
-          id: result.recruiter.id,
-          role: result.recruiter.role,
-        },
-        requiresVerification: true,
-      },
-      { status: 201 },
+/**
+ * アカウント作成後に認証メールを送信（失敗しても登録は成功扱い）
+ */
+async function sendVerificationSafely(
+  accountId: string,
+  email: string,
+): Promise<void> {
+  try {
+    await createAndSendVerificationToken(accountId, email);
+  } catch (error) {
+    logger.error(
+      "Failed to send verification email after registration",
+      error instanceof Error ? error : new Error(String(error)),
+      { accountId, email },
     );
   }
+}
 
-  // 求職者登録
+export const POST = withRateLimitValidation(
+  RATE_LIMIT_PRESETS.REGISTER,
+  registerSchema,
+  async (body) => {
+    const { email, password, name, accountType, companyName } = body;
+
+    const existingAccount = await prisma.account.findUnique({
+      where: { email },
+    });
+
+    if (existingAccount) {
+      throw new ConflictError("このメールアドレスは既に登録されています");
+    }
+
+    const passwordHash = await hash(password, 12);
+
+    try {
+      if (accountType === "RECRUITER") {
+        return await registerRecruiter(
+          email,
+          passwordHash,
+          accountType,
+          companyName as string,
+        );
+      }
+
+      return await registerUser(email, passwordHash, accountType, name);
+    } catch (error) {
+      if (isUniqueConstraintError(error)) {
+        throw new ConflictError("このメールアドレスは既に登録されています");
+      }
+      throw error;
+    }
+  },
+);
+
+async function registerRecruiter(
+  email: string,
+  passwordHash: string,
+  accountType: string,
+  companyName: string,
+): Promise<NextResponse> {
+  const slug = await generateUniqueSlug(companyName);
+
+  const result = await prisma.$transaction(async (tx) => {
+    const account = await tx.account.create({
+      data: {
+        email,
+        passwordHash,
+        accountType: accountType as AccountType,
+      },
+    });
+
+    const company = await tx.company.create({
+      data: {
+        name: companyName,
+        slug,
+        createdByAccountId: account.id,
+      },
+    });
+
+    const recruiter = await tx.recruiter.create({
+      data: {
+        accountId: account.id,
+        companyId: company.id,
+        role: "OWNER",
+        status: "ACTIVE",
+        joinedAt: new Date(),
+      },
+    });
+
+    return { account, company, recruiter };
+  });
+
+  await sendVerificationSafely(result.account.id, email);
+
+  return NextResponse.json(
+    {
+      account: {
+        id: result.account.id,
+        email: result.account.email,
+        accountType: result.account.accountType,
+      },
+      company: {
+        id: result.company.id,
+        name: result.company.name,
+        slug: result.company.slug,
+      },
+      recruiter: {
+        id: result.recruiter.id,
+        role: result.recruiter.role,
+      },
+      requiresVerification: true,
+    },
+    { status: 201 },
+  );
+}
+
+async function registerUser(
+  email: string,
+  passwordHash: string,
+  accountType: string,
+  name: string,
+): Promise<NextResponse> {
   const account = await prisma.account.create({
     data: {
       email,
@@ -121,7 +183,7 @@ export const POST = withValidation(registerSchema, async (body, req) => {
     },
   });
 
-  await createAndSendVerificationToken(account.id, email);
+  await sendVerificationSafely(account.id, email);
 
   return NextResponse.json(
     {
@@ -134,4 +196,4 @@ export const POST = withValidation(registerSchema, async (body, req) => {
     },
     { status: 201 },
   );
-});
+}

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -124,7 +124,14 @@ export const POST = withValidation(registerSchema, async (body, req) => {
   await createAndSendVerificationToken(account.id, email);
 
   return NextResponse.json(
-    { account, requiresVerification: true },
+    {
+      account: {
+        id: account.id,
+        email: account.email,
+        accountType: account.accountType,
+      },
+      requiresVerification: true,
+    },
     { status: 201 },
   );
 });

--- a/src/app/api/auth/resend-verification/route.ts
+++ b/src/app/api/auth/resend-verification/route.ts
@@ -1,21 +1,26 @@
 import { z } from "zod";
-import { apiSuccess, withValidation } from "@/lib/api-utils";
+import { apiSuccess, withRateLimitValidation } from "@/lib/api-utils";
 import { prisma } from "@/lib/prisma";
+import { RATE_LIMIT_PRESETS } from "@/lib/rate-limiter";
 import { createAndSendVerificationToken } from "@/lib/verification";
 
 const schema = z.object({
   email: z.string().email("有効なメールアドレスを入力してください"),
 });
 
-export const POST = withValidation(schema, async (body) => {
-  const account = await prisma.account.findUnique({
-    where: { email: body.email },
-  });
+export const POST = withRateLimitValidation(
+  RATE_LIMIT_PRESETS.VERIFY_EMAIL,
+  schema,
+  async (body) => {
+    const account = await prisma.account.findUnique({
+      where: { email: body.email },
+    });
 
-  // アカウント有無に関わらず同じレスポンス（情報漏洩防止）
-  if (account && !account.emailVerified) {
-    await createAndSendVerificationToken(account.id, account.email);
-  }
+    // アカウント有無に関わらず同じレスポンス（情報漏洩防止）
+    if (account && !account.emailVerified) {
+      await createAndSendVerificationToken(account.id, account.email);
+    }
 
-  return apiSuccess({ sent: true });
-});
+    return apiSuccess({ sent: true });
+  },
+);

--- a/src/app/api/auth/verify-email/route.ts
+++ b/src/app/api/auth/verify-email/route.ts
@@ -1,12 +1,17 @@
 import { z } from "zod";
-import { apiSuccess, withValidation } from "@/lib/api-utils";
+import { apiSuccess, withRateLimitValidation } from "@/lib/api-utils";
+import { RATE_LIMIT_PRESETS } from "@/lib/rate-limiter";
 import { verifyEmailToken } from "@/lib/verification";
 
 const schema = z.object({
   token: z.string().min(1, "トークンが必要です"),
 });
 
-export const POST = withValidation(schema, async (body) => {
-  await verifyEmailToken(body.token);
-  return apiSuccess({ verified: true });
-});
+export const POST = withRateLimitValidation(
+  RATE_LIMIT_PRESETS.VERIFY_EMAIL,
+  schema,
+  async (body) => {
+    await verifyEmailToken(body.token);
+    return apiSuccess({ verified: true });
+  },
+);

--- a/src/app/api/chat/messages/route.ts
+++ b/src/app/api/chat/messages/route.ts
@@ -11,6 +11,7 @@ export const GET = withUserAuth(async (_req, session) => {
     include: {
       messages: {
         orderBy: { createdAt: "asc" },
+        take: 500,
       },
     },
   });

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -140,7 +140,7 @@ const NEW_MESSAGE_COUNT = 4;
 const CONTEXT_MESSAGE_COUNT = 4;
 
 const chatSchema = z.object({
-  message: z.string().min(1),
+  message: z.string().min(1).max(5000),
   correctFragmentId: z.string().uuid().optional(),
 });
 

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -278,6 +278,11 @@ export const POST = withUserValidation(
         }
 
         let fragmentsExtracted = 0;
+        let extractedFragmentDetails: {
+          type: string;
+          content: string;
+          skills: string[];
+        }[] = [];
         let pendingCorrection:
           | {
               type: string;
@@ -356,6 +361,11 @@ export const POST = withUserValidation(
                 })),
               });
               fragmentsExtracted = extractedData.fragments.length;
+              extractedFragmentDetails = extractedData.fragments.map((f) => ({
+                type: parseFragmentType(f.type),
+                content: f.content,
+                skills: f.skills || [],
+              }));
 
               const allFragments = await prisma.fragment.findMany({
                 where: { userId: session.user.userId },
@@ -374,6 +384,7 @@ export const POST = withUserValidation(
           "metadata",
           JSON.stringify({
             fragmentsExtracted,
+            fragments: extractedFragmentDetails,
             pendingCorrection,
             coverage: currentCoverage,
           }),

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -150,7 +150,10 @@ export const POST = withUserValidation(
     const { message, correctFragmentId } = body;
 
     // セッション取得/作成
-    const chatSession = await getOrCreateUserAIChatSession(session.user.userId);
+    const chatSession = await getOrCreateUserAIChatSession(
+      session.user.userId,
+      MAX_LLM_MESSAGES + 10,
+    );
 
     // 修正対象フラグメントの取得
     let correctFragment: {

--- a/src/app/api/documents/[id]/analyze/__tests__/analyze.test.ts
+++ b/src/app/api/documents/[id]/analyze/__tests__/analyze.test.ts
@@ -1,0 +1,269 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// NextAuth モック
+const mockGetServerSession = vi.fn();
+vi.mock("next-auth", () => ({
+  getServerSession: () => mockGetServerSession(),
+}));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+
+// Logger モック
+const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+vi.mock("@/lib/logger", () => ({ logger: mockLogger }));
+
+// Lambda モック
+const mockLambdaSend = vi.fn();
+vi.mock("@aws-sdk/client-lambda", () => {
+  return {
+    LambdaClient: class MockLambdaClient {
+      send = mockLambdaSend;
+    },
+    InvokeCommand: class MockInvokeCommand {
+      constructor(public params: unknown) {}
+    },
+  };
+});
+
+// Prisma トランザクション用クライアント
+const mockTxClient = {
+  $queryRaw: vi.fn(),
+  document: { update: vi.fn() },
+};
+
+// Prisma メインクライアント
+const mockPrisma = {
+  $transaction: vi.fn(),
+  document: { update: vi.fn() },
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+const USER_ID = "user-123";
+const DOC_ID = "doc-456";
+
+const userSession = {
+  user: { accountId: "acc-1", userId: USER_ID },
+};
+
+const mockDocument = {
+  id: DOC_ID,
+  userId: USER_ID,
+  fileName: "resume.pdf",
+  filePath: "uploads/resume.pdf",
+  analysisStatus: "PENDING",
+  analyzedAt: null,
+  createdAt: new Date("2025-01-01"),
+};
+
+function createRequest(): NextRequest {
+  return new NextRequest(`http://localhost/api/documents/${DOC_ID}/analyze`, {
+    method: "POST",
+  });
+}
+
+const routeContext = { params: Promise.resolve({ id: DOC_ID }) };
+
+describe("POST /api/documents/[id]/analyze", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("DOCUMENT_ANALYSIS_LAMBDA_ARN", "arn:aws:lambda:test:fn");
+    mockGetServerSession.mockResolvedValue(userSession);
+    mockLambdaSend.mockResolvedValue({});
+    mockPrisma.document.update.mockResolvedValue({});
+    mockTxClient.document.update.mockResolvedValue({});
+    mockPrisma.$transaction.mockImplementation(
+      async (callback: (tx: typeof mockTxClient) => Promise<unknown>) => {
+        return callback(mockTxClient);
+      },
+    );
+  });
+
+  describe("認証・前提条件", () => {
+    it("未認証の場合は401を返す", async () => {
+      mockGetServerSession.mockResolvedValue(null);
+      const { POST } = await import("@/app/api/documents/[id]/analyze/route");
+
+      const res = await POST(createRequest(), routeContext);
+      expect(res.status).toBe(401);
+    });
+
+    it("userIdがない場合は403を返す", async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { accountId: "acc-1" },
+      });
+      const { POST } = await import("@/app/api/documents/[id]/analyze/route");
+
+      const res = await POST(createRequest(), routeContext);
+      expect(res.status).toBe(403);
+    });
+
+    it("DOCUMENT_ANALYSIS_LAMBDA_ARNが未設定の場合は500を返す", async () => {
+      vi.stubEnv("DOCUMENT_ANALYSIS_LAMBDA_ARN", "");
+      const { POST } = await import("@/app/api/documents/[id]/analyze/route");
+
+      const res = await POST(createRequest(), routeContext);
+      expect(res.status).toBe(500);
+    });
+  });
+
+  describe("ドキュメント検証", () => {
+    it("ドキュメントが存在しない場合は404を返す", async () => {
+      mockTxClient.$queryRaw.mockResolvedValue([]);
+      const { POST } = await import("@/app/api/documents/[id]/analyze/route");
+
+      const res = await POST(createRequest(), routeContext);
+      expect(res.status).toBe(404);
+    });
+
+    it("他ユーザーのドキュメントは取得できない（FOR UPDATE内のWHERE句）", async () => {
+      mockTxClient.$queryRaw.mockResolvedValue([]);
+      const { POST } = await import("@/app/api/documents/[id]/analyze/route");
+
+      const res = await POST(createRequest(), routeContext);
+      expect(res.status).toBe(404);
+
+      // SQLにuserIdが含まれていることを確認
+      expect(mockTxClient.$queryRaw).toHaveBeenCalled();
+    });
+  });
+
+  describe("解析ステータスチェック（排他ロック内）", () => {
+    it("ANALYZING状態で10分以内の場合は409を返す", async () => {
+      mockTxClient.$queryRaw.mockResolvedValue([
+        {
+          ...mockDocument,
+          analysisStatus: "ANALYZING",
+          analyzedAt: new Date(), // just started
+        },
+      ]);
+      const { POST } = await import("@/app/api/documents/[id]/analyze/route");
+
+      const res = await POST(createRequest(), routeContext);
+      expect(res.status).toBe(409);
+      const data = await res.json();
+      expect(data.error).toContain("解析中");
+    });
+
+    it("ANALYZING状態で10分超（stale）の場合は再解析を許可する", async () => {
+      mockTxClient.$queryRaw.mockResolvedValue([
+        {
+          ...mockDocument,
+          analysisStatus: "ANALYZING",
+          analyzedAt: new Date(Date.now() - 11 * 60 * 1000), // 11分前
+        },
+      ]);
+      const { POST } = await import("@/app/api/documents/[id]/analyze/route");
+
+      const res = await POST(createRequest(), routeContext);
+      expect(res.status).toBe(202);
+    });
+
+    it("PENDING状態のドキュメントは解析開始できる", async () => {
+      mockTxClient.$queryRaw.mockResolvedValue([mockDocument]);
+      const { POST } = await import("@/app/api/documents/[id]/analyze/route");
+
+      const res = await POST(createRequest(), routeContext);
+      expect(res.status).toBe(202);
+    });
+
+    it("COMPLETED状態のドキュメントも再解析できる", async () => {
+      mockTxClient.$queryRaw.mockResolvedValue([
+        { ...mockDocument, analysisStatus: "COMPLETED" },
+      ]);
+      const { POST } = await import("@/app/api/documents/[id]/analyze/route");
+
+      const res = await POST(createRequest(), routeContext);
+      expect(res.status).toBe(202);
+    });
+
+    it("FAILED状態のドキュメントも再解析できる", async () => {
+      mockTxClient.$queryRaw.mockResolvedValue([
+        { ...mockDocument, analysisStatus: "FAILED" },
+      ]);
+      const { POST } = await import("@/app/api/documents/[id]/analyze/route");
+
+      const res = await POST(createRequest(), routeContext);
+      expect(res.status).toBe(202);
+    });
+  });
+
+  describe("正常系", () => {
+    it("トランザクション内でステータスをANALYZINGに更新する", async () => {
+      mockTxClient.$queryRaw.mockResolvedValue([mockDocument]);
+      const { POST } = await import("@/app/api/documents/[id]/analyze/route");
+
+      await POST(createRequest(), routeContext);
+
+      expect(mockTxClient.document.update).toHaveBeenCalledWith({
+        where: { id: DOC_ID },
+        data: {
+          analysisStatus: "ANALYZING",
+          analysisError: null,
+          analyzedAt: expect.any(Date),
+        },
+      });
+    });
+
+    it("Lambda関数を非同期で呼び出す", async () => {
+      mockTxClient.$queryRaw.mockResolvedValue([mockDocument]);
+      const { POST } = await import("@/app/api/documents/[id]/analyze/route");
+
+      await POST(createRequest(), routeContext);
+
+      expect(mockLambdaSend).toHaveBeenCalledTimes(1);
+      const invokeCmd = mockLambdaSend.mock.calls[0][0];
+      expect(invokeCmd.params).toEqual(
+        expect.objectContaining({
+          FunctionName: "arn:aws:lambda:test:fn",
+          InvocationType: "Event",
+          Payload: expect.stringContaining(DOC_ID),
+        }),
+      );
+    });
+
+    it("202レスポンスを返す", async () => {
+      mockTxClient.$queryRaw.mockResolvedValue([mockDocument]);
+      const { POST } = await import("@/app/api/documents/[id]/analyze/route");
+
+      const res = await POST(createRequest(), routeContext);
+      expect(res.status).toBe(202);
+      const data = await res.json();
+      expect(data.success).toBe(true);
+      expect(data.analysisStatus).toBe("ANALYZING");
+    });
+  });
+
+  describe("Lambda呼び出し失敗", () => {
+    it("Lambda失敗時はステータスをFAILEDに戻す", async () => {
+      mockTxClient.$queryRaw.mockResolvedValue([mockDocument]);
+      mockLambdaSend.mockRejectedValue(new Error("Lambda timeout"));
+      const { POST } = await import("@/app/api/documents/[id]/analyze/route");
+
+      const res = await POST(createRequest(), routeContext);
+      expect(res.status).toBe(500);
+
+      expect(mockPrisma.document.update).toHaveBeenCalledWith({
+        where: { id: DOC_ID },
+        data: {
+          analysisStatus: "FAILED",
+          analysisError: "解析ジョブの開始に失敗しました",
+        },
+      });
+    });
+
+    it("Lambda失敗時にエラーをログ出力する", async () => {
+      mockTxClient.$queryRaw.mockResolvedValue([mockDocument]);
+      const lambdaError = new Error("Service unavailable");
+      mockLambdaSend.mockRejectedValue(lambdaError);
+      const { POST } = await import("@/app/api/documents/[id]/analyze/route");
+
+      await POST(createRequest(), routeContext);
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "Lambda invocation failed",
+        lambdaError,
+        expect.objectContaining({ documentId: DOC_ID }),
+      );
+    });
+  });
+});

--- a/src/app/api/documents/[id]/analyze/route.ts
+++ b/src/app/api/documents/[id]/analyze/route.ts
@@ -66,6 +66,10 @@ export const POST = withUserAuth<RouteContext>(
         }),
       );
     } catch (error) {
+      logger.error("Lambda invocation failed", error as Error, {
+        documentId: id,
+        lambdaArn,
+      });
       await prisma.document.update({
         where: { id },
         data: {

--- a/src/app/api/documents/[id]/analyze/stream/route.ts
+++ b/src/app/api/documents/[id]/analyze/stream/route.ts
@@ -70,10 +70,14 @@ export const GET = withUserAuth<RouteContext>(
             }
 
             if (doc.analysisStatus === "COMPLETED") {
+              const fragmentCount = await prisma.fragment.count({
+                where: { sourceType: "DOCUMENT", sourceId: id },
+              });
               send("completed", {
                 status: "COMPLETED",
                 summary: doc.summary,
                 analyzedAt: doc.analyzedAt,
+                fragmentCount,
               });
               controller.close();
               return;

--- a/src/app/api/documents/[id]/fragments/__tests__/document-fragments.test.ts
+++ b/src/app/api/documents/[id]/fragments/__tests__/document-fragments.test.ts
@@ -1,0 +1,137 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// NextAuth モック
+const mockGetServerSession = vi.fn();
+vi.mock("next-auth", () => ({
+  getServerSession: () => mockGetServerSession(),
+}));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+
+// Logger モック
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// Prisma モック
+const mockPrisma = {
+  document: { findFirst: vi.fn() },
+  fragment: { findMany: vi.fn() },
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+const USER_ID = "user-123";
+const DOC_ID = "doc-456";
+
+const userSession = {
+  user: { accountId: "acc-1", userId: USER_ID },
+};
+
+const routeContext = { params: Promise.resolve({ id: DOC_ID }) };
+
+function createRequest(): NextRequest {
+  return new NextRequest(`http://localhost/api/documents/${DOC_ID}/fragments`, {
+    method: "GET",
+  });
+}
+
+describe("GET /api/documents/[id]/fragments", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(userSession);
+  });
+
+  it("自分のドキュメントの Fragment を取得できる", async () => {
+    mockPrisma.document.findFirst.mockResolvedValue({
+      id: DOC_ID,
+      userId: USER_ID,
+    });
+    const mockFragments = [
+      {
+        id: "frag-1",
+        type: "ACHIEVEMENT",
+        content: "売上を200%達成",
+        skills: ["営業"],
+        keywords: ["売上"],
+        createdAt: new Date("2026-01-01"),
+      },
+      {
+        id: "frag-2",
+        type: "SKILL_USAGE",
+        content: "Pythonでデータ分析基盤を構築",
+        skills: ["Python", "データ分析"],
+        keywords: ["基盤"],
+        createdAt: new Date("2026-01-02"),
+      },
+    ];
+    mockPrisma.fragment.findMany.mockResolvedValue(mockFragments);
+
+    const { GET } = await import("@/app/api/documents/[id]/fragments/route");
+    const res = await GET(createRequest(), routeContext);
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.fragments).toHaveLength(2);
+    expect(data.fragments[0].id).toBe("frag-1");
+    expect(data.fragments[1].id).toBe("frag-2");
+
+    expect(mockPrisma.document.findFirst).toHaveBeenCalledWith({
+      where: { id: DOC_ID, userId: USER_ID },
+    });
+    expect(mockPrisma.fragment.findMany).toHaveBeenCalledWith({
+      where: { userId: USER_ID, sourceType: "DOCUMENT", sourceId: DOC_ID },
+      select: {
+        id: true,
+        type: true,
+        content: true,
+        skills: true,
+        keywords: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: "asc" },
+    });
+  });
+
+  it("Fragment が 0 件の場合は空配列を返す", async () => {
+    mockPrisma.document.findFirst.mockResolvedValue({
+      id: DOC_ID,
+      userId: USER_ID,
+    });
+    mockPrisma.fragment.findMany.mockResolvedValue([]);
+
+    const { GET } = await import("@/app/api/documents/[id]/fragments/route");
+    const res = await GET(createRequest(), routeContext);
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.fragments).toEqual([]);
+  });
+
+  it("未認証の場合は 401 を返す", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const { GET } = await import("@/app/api/documents/[id]/fragments/route");
+    const res = await GET(createRequest(), routeContext);
+
+    expect(res.status).toBe(401);
+  });
+
+  it("存在しないドキュメントの場合は 404 を返す", async () => {
+    mockPrisma.document.findFirst.mockResolvedValue(null);
+
+    const { GET } = await import("@/app/api/documents/[id]/fragments/route");
+    const res = await GET(createRequest(), routeContext);
+
+    expect(res.status).toBe(404);
+  });
+
+  it("他ユーザーのドキュメントの場合は 404 を返す", async () => {
+    // findFirst の where に userId が含まれるため、他ユーザーの場合は null が返る
+    mockPrisma.document.findFirst.mockResolvedValue(null);
+
+    const { GET } = await import("@/app/api/documents/[id]/fragments/route");
+    const res = await GET(createRequest(), routeContext);
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/app/api/documents/[id]/fragments/route.ts
+++ b/src/app/api/documents/[id]/fragments/route.ts
@@ -1,0 +1,40 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { withUserAuth } from "@/lib/api-utils";
+import { NotFoundError } from "@/lib/errors";
+import { prisma } from "@/lib/prisma";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export const GET = withUserAuth<RouteContext>(
+  async (_req: NextRequest, session, context) => {
+    const { id } = await context.params;
+
+    const document = await prisma.document.findFirst({
+      where: { id, userId: session.user.userId },
+    });
+
+    if (!document) {
+      throw new NotFoundError("ドキュメントが見つかりません");
+    }
+
+    const fragments = await prisma.fragment.findMany({
+      where: {
+        userId: session.user.userId,
+        sourceType: "DOCUMENT",
+        sourceId: id,
+      },
+      select: {
+        id: true,
+        type: true,
+        content: true,
+        skills: true,
+        keywords: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: "asc" },
+    });
+
+    return NextResponse.json({ fragments });
+  },
+);

--- a/src/app/api/interests/[id]/messages/__tests__/messages.test.ts
+++ b/src/app/api/interests/[id]/messages/__tests__/messages.test.ts
@@ -1,0 +1,692 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mocks ──────────────────────────────────────────────────────────
+
+// Logger
+const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+vi.mock("@/lib/logger", () => ({ logger: mockLogger }));
+
+// NextAuth
+const mockGetServerSession = vi.fn();
+vi.mock("next-auth", () => ({
+  getServerSession: (...args: unknown[]) => mockGetServerSession(...args),
+}));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+
+// Points
+const mockConsumePointsWithOperations = vi.fn();
+vi.mock("@/lib/points", () => ({
+  consumePointsWithOperations: (...args: unknown[]) =>
+    mockConsumePointsWithOperations(...args),
+}));
+
+// Prisma
+const mockPrisma = {
+  interest: {
+    findUnique: vi.fn(),
+    updateMany: vi.fn(),
+  },
+  directMessage: {
+    findMany: vi.fn(),
+    create: vi.fn(),
+  },
+  notification: {
+    create: vi.fn(),
+  },
+  $transaction: vi.fn(),
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+// ── Constants ──────────────────────────────────────────────────────
+
+const INTEREST_ID = "interest-001";
+const RECRUITER_ID = "rec-001";
+const USER_ID = "user-001";
+const COMPANY_ID = "company-001";
+const RECRUITER_ACCOUNT_ID = "acc-rec-001";
+const USER_ACCOUNT_ID = "acc-user-001";
+
+const routeContext = {
+  params: Promise.resolve({ id: INTEREST_ID }),
+};
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function recruiterSession() {
+  return {
+    user: {
+      accountId: RECRUITER_ACCOUNT_ID,
+      accountType: "RECRUITER",
+      recruiterId: RECRUITER_ID,
+      companyId: COMPANY_ID,
+      userId: null,
+    },
+  };
+}
+
+function userSession() {
+  return {
+    user: {
+      accountId: USER_ACCOUNT_ID,
+      accountType: "USER",
+      userId: USER_ID,
+      recruiterId: null,
+      companyId: null,
+    },
+  };
+}
+
+function mockInterest(overrides = {}) {
+  return {
+    id: INTEREST_ID,
+    recruiterId: RECRUITER_ID,
+    userId: USER_ID,
+    status: "CONTACT_DISCLOSED",
+    user: {
+      id: USER_ID,
+      name: "テスト太郎",
+      accountId: USER_ACCOUNT_ID,
+    },
+    recruiter: {
+      id: RECRUITER_ID,
+      companyId: COMPANY_ID,
+      accountId: RECRUITER_ACCOUNT_ID,
+      company: { name: "テスト株式会社" },
+    },
+    ...overrides,
+  };
+}
+
+function createGetRequest(): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/interests/${INTEREST_ID}/messages`,
+    { method: "GET" },
+  );
+}
+
+function createPostRequest(body: unknown): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/interests/${INTEREST_ID}/messages`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+async function importRoute() {
+  return import("@/app/api/interests/[id]/messages/route");
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+describe("GET /api/interests/[id]/messages", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("認証済みリクルーターがメッセージ一覧を取得できる", async () => {
+    mockGetServerSession.mockResolvedValue(recruiterSession());
+    mockPrisma.interest.findUnique.mockResolvedValue({
+      id: INTEREST_ID,
+      recruiterId: RECRUITER_ID,
+      userId: USER_ID,
+    });
+    mockPrisma.directMessage.findMany.mockResolvedValue([
+      {
+        id: "msg-1",
+        content: "こんにちは",
+        senderType: "RECRUITER",
+        createdAt: new Date("2025-01-01"),
+        recruiter: { id: RECRUITER_ID, company: { name: "テスト株式会社" } },
+        user: null,
+      },
+    ]);
+
+    const { GET } = await importRoute();
+    const res = await GET(createGetRequest(), routeContext);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.messages).toHaveLength(1);
+    expect(body.messages[0].recruiter.companyName).toBe("テスト株式会社");
+  });
+
+  it("認証済み求職者がメッセージ一覧を取得できる", async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+    mockPrisma.interest.findUnique.mockResolvedValue({
+      id: INTEREST_ID,
+      recruiterId: RECRUITER_ID,
+      userId: USER_ID,
+    });
+    mockPrisma.directMessage.findMany.mockResolvedValue([]);
+
+    const { GET } = await importRoute();
+    const res = await GET(createGetRequest(), routeContext);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.messages).toHaveLength(0);
+  });
+
+  it("興味表明が見つからない場合は404を返す", async () => {
+    mockGetServerSession.mockResolvedValue(recruiterSession());
+    mockPrisma.interest.findUnique.mockResolvedValue(null);
+
+    const { GET } = await importRoute();
+    const res = await GET(createGetRequest(), routeContext);
+    expect(res.status).toBe(404);
+  });
+
+  it("関係のないユーザーは403を返す", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: {
+        accountId: "acc-other",
+        accountType: "USER",
+        userId: "other-user",
+        recruiterId: null,
+      },
+    });
+    mockPrisma.interest.findUnique.mockResolvedValue({
+      id: INTEREST_ID,
+      recruiterId: RECRUITER_ID,
+      userId: USER_ID,
+    });
+
+    const { GET } = await importRoute();
+    const res = await GET(createGetRequest(), routeContext);
+    expect(res.status).toBe(403);
+  });
+
+  it("未認証の場合は401を返す", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const { GET } = await importRoute();
+    const res = await GET(createGetRequest(), routeContext);
+    expect(res.status).toBe(401);
+  });
+
+  it("recruiterがnullのメッセージはrecruiter: nullとして返す", async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+    mockPrisma.interest.findUnique.mockResolvedValue({
+      id: INTEREST_ID,
+      recruiterId: RECRUITER_ID,
+      userId: USER_ID,
+    });
+    mockPrisma.directMessage.findMany.mockResolvedValue([
+      {
+        id: "msg-1",
+        content: "返信です",
+        senderType: "USER",
+        createdAt: new Date("2025-01-01"),
+        recruiter: null,
+        user: { id: USER_ID, name: "テスト太郎" },
+      },
+    ]);
+
+    const { GET } = await importRoute();
+    const res = await GET(createGetRequest(), routeContext);
+    const body = await res.json();
+    expect(body.messages[0].recruiter).toBeNull();
+  });
+});
+
+describe("POST /api/interests/[id]/messages", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── バリデーション ──────────────────────────────────────────
+
+  describe("バリデーション", () => {
+    it("空のcontentで400を返す", async () => {
+      mockGetServerSession.mockResolvedValue(recruiterSession());
+      mockPrisma.interest.findUnique.mockResolvedValue(mockInterest());
+
+      const { POST } = await importRoute();
+      const res = await POST(createPostRequest({ content: "" }), routeContext);
+      expect(res.status).toBe(400);
+    });
+
+    it("5000文字超のcontentで400を返す", async () => {
+      mockGetServerSession.mockResolvedValue(recruiterSession());
+      mockPrisma.interest.findUnique.mockResolvedValue(mockInterest());
+
+      const { POST } = await importRoute();
+      const res = await POST(
+        createPostRequest({ content: "a".repeat(5001) }),
+        routeContext,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("contentが未指定で400を返す", async () => {
+      mockGetServerSession.mockResolvedValue(recruiterSession());
+      mockPrisma.interest.findUnique.mockResolvedValue(mockInterest());
+
+      const { POST } = await importRoute();
+      const res = await POST(createPostRequest({}), routeContext);
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // ── 認証・認可 ──────────────────────────────────────────────
+
+  describe("認証・認可", () => {
+    it("未認証の場合は401を返す", async () => {
+      mockGetServerSession.mockResolvedValue(null);
+
+      const { POST } = await importRoute();
+      const res = await POST(
+        createPostRequest({ content: "hello" }),
+        routeContext,
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it("興味表明が見つからない場合は404を返す", async () => {
+      mockGetServerSession.mockResolvedValue(recruiterSession());
+      mockPrisma.interest.findUnique.mockResolvedValue(null);
+
+      const { POST } = await importRoute();
+      const res = await POST(
+        createPostRequest({ content: "hello" }),
+        routeContext,
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it("CONTACT_DISCLOSED以外のステータスで403を返す", async () => {
+      mockGetServerSession.mockResolvedValue(recruiterSession());
+      mockPrisma.interest.findUnique.mockResolvedValue(
+        mockInterest({ status: "EXPRESSED" }),
+      );
+
+      const { POST } = await importRoute();
+      const res = await POST(
+        createPostRequest({ content: "hello" }),
+        routeContext,
+      );
+      expect(res.status).toBe(403);
+    });
+
+    it("関係のないユーザーは403を返す", async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: {
+          accountId: "acc-other",
+          accountType: "USER",
+          userId: "other-user",
+          recruiterId: null,
+        },
+      });
+      mockPrisma.interest.findUnique.mockResolvedValue(mockInterest());
+
+      const { POST } = await importRoute();
+      const res = await POST(
+        createPostRequest({ content: "hello" }),
+        routeContext,
+      );
+      expect(res.status).toBe(403);
+    });
+  });
+
+  // ── リクルーターのメッセージ送信 ──────────────────────────
+
+  describe("リクルーター送信", () => {
+    beforeEach(() => {
+      mockGetServerSession.mockResolvedValue(recruiterSession());
+      mockPrisma.interest.findUnique.mockResolvedValue(mockInterest());
+    });
+
+    it("メッセージ送信成功で201を返す", async () => {
+      const createdMsg = {
+        id: "msg-new",
+        interestId: INTEREST_ID,
+        senderId: RECRUITER_ID,
+        senderType: "RECRUITER",
+        content: "面接のご案内",
+        createdAt: new Date(),
+      };
+      mockConsumePointsWithOperations.mockImplementation(
+        async (
+          _companyId: string,
+          _action: string,
+          operations: (tx: unknown) => Promise<unknown>,
+        ) => {
+          const mockTx = {
+            interest: {
+              updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+            },
+            directMessage: { create: vi.fn().mockResolvedValue(createdMsg) },
+            notification: { create: vi.fn().mockResolvedValue({}) },
+          };
+          const result = await operations(mockTx);
+          return { newBalance: 47, consumed: 3, result };
+        },
+      );
+
+      const { POST } = await importRoute();
+      const res = await POST(
+        createPostRequest({ content: "面接のご案内" }),
+        routeContext,
+      );
+      expect(res.status).toBe(201);
+
+      const body = await res.json();
+      expect(body.message.id).toBe("msg-new");
+    });
+
+    it("consumePointsWithOperationsに正しいパラメータを渡す", async () => {
+      mockConsumePointsWithOperations.mockImplementation(
+        async (
+          _companyId: string,
+          _action: string,
+          operations: (tx: unknown) => Promise<unknown>,
+        ) => {
+          const mockTx = {
+            interest: {
+              updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+            },
+            directMessage: {
+              create: vi.fn().mockResolvedValue({ id: "msg-new" }),
+            },
+            notification: { create: vi.fn().mockResolvedValue({}) },
+          };
+          const result = await operations(mockTx);
+          return { newBalance: 47, consumed: 3, result };
+        },
+      );
+
+      const { POST } = await importRoute();
+      await POST(createPostRequest({ content: "test" }), routeContext);
+
+      expect(mockConsumePointsWithOperations).toHaveBeenCalledWith(
+        COMPANY_ID,
+        "MESSAGE_SEND",
+        expect.any(Function),
+        INTEREST_ID,
+        `メッセージ送信: テスト太郎`,
+      );
+    });
+
+    it("トランザクション内で通知を作成する", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let capturedTx: any;
+      mockConsumePointsWithOperations.mockImplementation(
+        async (
+          _companyId: string,
+          _action: string,
+          operations: (tx: unknown) => Promise<unknown>,
+        ) => {
+          const mockTx = {
+            interest: {
+              updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+            },
+            directMessage: {
+              create: vi.fn().mockResolvedValue({ id: "msg-new" }),
+            },
+            notification: { create: vi.fn().mockResolvedValue({}) },
+          };
+          capturedTx = mockTx;
+          const result = await operations(mockTx);
+          return { newBalance: 47, consumed: 3, result };
+        },
+      );
+
+      const { POST } = await importRoute();
+      await POST(createPostRequest({ content: "hello" }), routeContext);
+
+      expect(capturedTx!.notification.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          accountId: USER_ACCOUNT_ID,
+          type: "SYSTEM",
+          title: "新しいメッセージ",
+          body: "テスト株式会社からメッセージが届きました",
+        }),
+      });
+    });
+
+    it("contentの前後の空白がトリムされる", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let capturedTx: any;
+      mockConsumePointsWithOperations.mockImplementation(
+        async (
+          _companyId: string,
+          _action: string,
+          operations: (tx: unknown) => Promise<unknown>,
+        ) => {
+          const mockTx = {
+            interest: {
+              updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+            },
+            directMessage: {
+              create: vi.fn().mockResolvedValue({ id: "msg-new" }),
+            },
+            notification: { create: vi.fn().mockResolvedValue({}) },
+          };
+          capturedTx = mockTx;
+          const result = await operations(mockTx);
+          return { newBalance: 47, consumed: 3, result };
+        },
+      );
+
+      const { POST } = await importRoute();
+      await POST(createPostRequest({ content: "  trimmed  " }), routeContext);
+
+      expect(capturedTx!.directMessage.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          content: "trimmed",
+        }),
+      });
+    });
+  });
+
+  // ── 求職者のメッセージ送信 ──────────────────────────────────
+
+  describe("求職者送信", () => {
+    beforeEach(() => {
+      mockGetServerSession.mockResolvedValue(userSession());
+      mockPrisma.interest.findUnique.mockResolvedValue(mockInterest());
+    });
+
+    it("メッセージ送信成功で201を返す（ポイント消費なし）", async () => {
+      const createdMsg = {
+        id: "msg-user",
+        interestId: INTEREST_ID,
+        senderId: USER_ID,
+        senderType: "USER",
+        content: "ありがとうございます",
+        createdAt: new Date(),
+      };
+
+      const mockTxClient = {
+        interest: {
+          updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+        },
+        directMessage: { create: vi.fn().mockResolvedValue(createdMsg) },
+        notification: { create: vi.fn().mockResolvedValue({}) },
+      };
+      mockPrisma.$transaction.mockImplementation(
+        async (callback: (tx: typeof mockTxClient) => Promise<unknown>) => {
+          return callback(mockTxClient);
+        },
+      );
+
+      const { POST } = await importRoute();
+      const res = await POST(
+        createPostRequest({ content: "ありがとうございます" }),
+        routeContext,
+      );
+      expect(res.status).toBe(201);
+
+      const body = await res.json();
+      expect(body.message.id).toBe("msg-user");
+
+      // consumePointsWithOperationsは呼ばれない
+      expect(mockConsumePointsWithOperations).not.toHaveBeenCalled();
+    });
+
+    it("トランザクション内で通知を作成する（相手はリクルーター）", async () => {
+      const mockTxClient = {
+        interest: {
+          updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+        },
+        directMessage: {
+          create: vi.fn().mockResolvedValue({ id: "msg-user" }),
+        },
+        notification: { create: vi.fn().mockResolvedValue({}) },
+      };
+      mockPrisma.$transaction.mockImplementation(
+        async (callback: (tx: typeof mockTxClient) => Promise<unknown>) => {
+          return callback(mockTxClient);
+        },
+      );
+
+      const { POST } = await importRoute();
+      await POST(createPostRequest({ content: "hello" }), routeContext);
+
+      expect(mockTxClient.notification.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          accountId: RECRUITER_ACCOUNT_ID,
+          type: "SYSTEM",
+          title: "新しいメッセージ",
+          body: "テスト太郎からメッセージが届きました",
+        }),
+      });
+    });
+  });
+
+  // ── TOCTOU防止 ──────────────────────────────────────────────
+
+  describe("TOCTOU防止（ステータス競合）", () => {
+    it("リクルーターパス: トランザクション内でステータスが変更されていたら409を返す", async () => {
+      mockGetServerSession.mockResolvedValue(recruiterSession());
+      mockPrisma.interest.findUnique.mockResolvedValue(mockInterest());
+
+      // consumePointsWithOperations内のtx.interest.updateManyが0件を返す
+      // （ステータスがCONTACT_DISCLOSEDではなくなっている）
+      mockConsumePointsWithOperations.mockImplementation(
+        async (
+          _companyId: string,
+          _action: string,
+          operations: (tx: unknown) => Promise<unknown>,
+        ) => {
+          const mockTx = {
+            interest: {
+              updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+            },
+            directMessage: { create: vi.fn() },
+            notification: { create: vi.fn() },
+          };
+          const result = await operations(mockTx);
+          return { newBalance: 47, consumed: 3, result };
+        },
+      );
+
+      const { POST } = await importRoute();
+      const res = await POST(
+        createPostRequest({ content: "hello" }),
+        routeContext,
+      );
+      expect(res.status).toBe(409);
+
+      const body = await res.json();
+      expect(body.error).toContain("開示状態が変更");
+    });
+
+    it("求職者パス: トランザクション内でステータスが変更されていたら409を返す", async () => {
+      mockGetServerSession.mockResolvedValue(userSession());
+      mockPrisma.interest.findUnique.mockResolvedValue(mockInterest());
+
+      const mockTxClient = {
+        interest: {
+          // ステータスが変更されていて0件マッチ
+          updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+        },
+        directMessage: { create: vi.fn() },
+        notification: { create: vi.fn() },
+      };
+      mockPrisma.$transaction.mockImplementation(
+        async (callback: (tx: typeof mockTxClient) => Promise<unknown>) => {
+          return callback(mockTxClient);
+        },
+      );
+
+      const { POST } = await importRoute();
+      const res = await POST(
+        createPostRequest({ content: "hello" }),
+        routeContext,
+      );
+      expect(res.status).toBe(409);
+
+      const body = await res.json();
+      expect(body.error).toContain("開示状態が変更");
+    });
+
+    it("リクルーターパス: ステータスチェック後にメッセージが作成されないことを確認", async () => {
+      mockGetServerSession.mockResolvedValue(recruiterSession());
+      mockPrisma.interest.findUnique.mockResolvedValue(mockInterest());
+
+      let msgCreateCalled = false;
+      mockConsumePointsWithOperations.mockImplementation(
+        async (
+          _companyId: string,
+          _action: string,
+          operations: (tx: unknown) => Promise<unknown>,
+        ) => {
+          const mockTx = {
+            interest: {
+              updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+            },
+            directMessage: {
+              create: vi.fn().mockImplementation(() => {
+                msgCreateCalled = true;
+                return { id: "msg-new" };
+              }),
+            },
+            notification: { create: vi.fn() },
+          };
+          const result = await operations(mockTx);
+          return { newBalance: 47, consumed: 3, result };
+        },
+      );
+
+      const { POST } = await importRoute();
+      await POST(createPostRequest({ content: "hello" }), routeContext);
+
+      // ステータスチェック失敗後、directMessage.createは呼ばれない
+      expect(msgCreateCalled).toBe(false);
+    });
+
+    it("求職者パス: ステータスチェック後にメッセージが作成されないことを確認", async () => {
+      mockGetServerSession.mockResolvedValue(userSession());
+      mockPrisma.interest.findUnique.mockResolvedValue(mockInterest());
+
+      let msgCreateCalled = false;
+      const mockTxClient = {
+        interest: {
+          updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+        },
+        directMessage: {
+          create: vi.fn().mockImplementation(() => {
+            msgCreateCalled = true;
+            return { id: "msg-new" };
+          }),
+        },
+        notification: { create: vi.fn() },
+      };
+      mockPrisma.$transaction.mockImplementation(
+        async (callback: (tx: typeof mockTxClient) => Promise<unknown>) => {
+          return callback(mockTxClient);
+        },
+      );
+
+      const { POST } = await importRoute();
+      await POST(createPostRequest({ content: "hello" }), routeContext);
+
+      expect(msgCreateCalled).toBe(false);
+    });
+  });
+});

--- a/src/app/api/interests/[id]/request/__tests__/request.test.ts
+++ b/src/app/api/interests/[id]/request/__tests__/request.test.ts
@@ -1,0 +1,429 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mocks ──────────────────────────────────────────────────────────
+
+const mockGetServerSession = vi.fn();
+vi.mock("next-auth", () => ({
+  getServerSession: () => mockGetServerSession(),
+}));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+
+const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+vi.mock("@/lib/logger", () => ({ logger: mockLogger }));
+
+const mockPrisma = {
+  interest: {
+    findUnique: vi.fn(),
+    updateMany: vi.fn(),
+  },
+  companyAccess: {
+    findUnique: vi.fn(),
+  },
+  notification: {
+    create: vi.fn(),
+  },
+  $transaction: vi.fn(),
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+const mockCheckPointBalance = vi.fn();
+const mockConsumePointsWithOperations = vi.fn();
+vi.mock("@/lib/points", () => ({
+  checkPointBalance: (...args: unknown[]) => mockCheckPointBalance(...args),
+  consumePointsWithOperations: (...args: unknown[]) =>
+    mockConsumePointsWithOperations(...args),
+}));
+
+// ── Constants ──────────────────────────────────────────────────────
+
+const RECRUITER_ID = "recruiter-001";
+const COMPANY_ID = "company-001";
+const INTEREST_ID = "interest-001";
+const USER_ID = "user-001";
+
+const recruiterSession = {
+  user: {
+    accountId: "acc-1",
+    recruiterId: RECRUITER_ID,
+    companyId: COMPANY_ID,
+    accountType: "RECRUITER",
+    recruiterStatus: "ACTIVE",
+  },
+};
+
+const otherRecruiterSession = {
+  user: {
+    accountId: "acc-2",
+    recruiterId: "recruiter-999",
+    companyId: "company-999",
+    accountType: "RECRUITER",
+    recruiterStatus: "ACTIVE",
+  },
+};
+
+const mockInterest = {
+  id: INTEREST_ID,
+  recruiterId: RECRUITER_ID,
+  userId: USER_ID,
+  status: "EXPRESSED",
+  user: {
+    id: USER_ID,
+    name: "テスト太郎",
+    email: "test@example.com",
+    phone: "090-1234-5678",
+    accountId: "user-acc-1",
+  },
+  recruiter: {
+    id: RECRUITER_ID,
+    companyId: COMPANY_ID,
+    accountId: "acc-1",
+    company: { name: "テスト企業" },
+  },
+};
+
+const routeContext = {
+  params: Promise.resolve({ id: INTEREST_ID }),
+};
+
+function createPostRequest(): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/interests/${INTEREST_ID}/request`,
+    { method: "POST" },
+  );
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let capturedTx: any;
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+describe("POST /api/interests/[id]/request", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(recruiterSession);
+    capturedTx = null;
+
+    // デフォルト: トランザクションはコールバック実行
+    mockPrisma.$transaction.mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      async (callback: (tx: any) => Promise<unknown>) => {
+        capturedTx = {
+          interest: { updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
+          notification: { create: vi.fn().mockResolvedValue({}) },
+        };
+        return callback(capturedTx);
+      },
+    );
+  });
+
+  describe("認証・認可", () => {
+    it("未認証の場合401を返す", async () => {
+      mockGetServerSession.mockResolvedValue(null);
+
+      const { POST } = await import("@/app/api/interests/[id]/request/route");
+      const response = await POST(createPostRequest(), routeContext);
+
+      expect(response.status).toBe(401);
+    });
+
+    it("companyIdがない場合403を返す", async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: {
+          accountId: "acc-1",
+          recruiterId: RECRUITER_ID,
+          accountType: "RECRUITER",
+          recruiterStatus: "ACTIVE",
+        },
+      });
+
+      const { POST } = await import("@/app/api/interests/[id]/request/route");
+      const response = await POST(createPostRequest(), routeContext);
+
+      expect(response.status).toBe(403);
+    });
+
+    it("存在しない興味表明は404を返す", async () => {
+      mockPrisma.interest.findUnique.mockResolvedValue(null);
+
+      const { POST } = await import("@/app/api/interests/[id]/request/route");
+      const response = await POST(createPostRequest(), routeContext);
+
+      expect(response.status).toBe(404);
+    });
+
+    it("他リクルーターの興味表明は403を返す", async () => {
+      mockGetServerSession.mockResolvedValue(otherRecruiterSession);
+      mockPrisma.interest.findUnique.mockResolvedValue(mockInterest);
+
+      const { POST } = await import("@/app/api/interests/[id]/request/route");
+      const response = await POST(createPostRequest(), routeContext);
+
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("既存ステータス処理", () => {
+    it("CONTACT_DISCLOSED済みなら連絡先を返す", async () => {
+      mockPrisma.interest.findUnique.mockResolvedValue({
+        ...mockInterest,
+        status: "CONTACT_DISCLOSED",
+      });
+
+      const { POST } = await import("@/app/api/interests/[id]/request/route");
+      const response = await POST(createPostRequest(), routeContext);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.contact.email).toBe("test@example.com");
+      expect(data.contact.phone).toBe("090-1234-5678");
+      expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it("DECLINED済みなら409を返す", async () => {
+      mockPrisma.interest.findUnique.mockResolvedValue({
+        ...mockInterest,
+        status: "DECLINED",
+      });
+
+      const { POST } = await import("@/app/api/interests/[id]/request/route");
+      const response = await POST(createPostRequest(), routeContext);
+
+      expect(response.status).toBe(409);
+    });
+  });
+
+  describe("DENY（自動辞退）", () => {
+    beforeEach(() => {
+      mockPrisma.interest.findUnique.mockResolvedValue(mockInterest);
+      mockPrisma.companyAccess.findUnique.mockResolvedValue({
+        status: "DENY",
+      });
+    });
+
+    it("DENY設定で自動辞退される", async () => {
+      const { POST } = await import("@/app/api/interests/[id]/request/route");
+      const response = await POST(createPostRequest(), routeContext);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.status).toBe("DECLINED");
+      expect(data.auto).toBe(true);
+    });
+
+    it("条件付きupdateManyで辞退する（TOCTOU防止）", async () => {
+      const { POST } = await import("@/app/api/interests/[id]/request/route");
+      await POST(createPostRequest(), routeContext);
+
+      expect(capturedTx.interest.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: INTEREST_ID,
+          status: { in: ["EXPRESSED", "CONTACT_REQUESTED"] },
+        },
+        data: { status: "DECLINED" },
+      });
+    });
+
+    it("同時リクエストでステータス変更済みなら409を返す", async () => {
+      mockPrisma.$transaction.mockImplementation(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        async (callback: (tx: any) => Promise<unknown>) => {
+          capturedTx = {
+            interest: {
+              updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+            },
+            notification: { create: vi.fn() },
+          };
+          return callback(capturedTx);
+        },
+      );
+
+      const { POST } = await import("@/app/api/interests/[id]/request/route");
+      const response = await POST(createPostRequest(), routeContext);
+
+      expect(response.status).toBe(409);
+      expect(capturedTx.notification.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("ALLOW（自動連絡先開示・ポイント消費）", () => {
+    beforeEach(() => {
+      mockPrisma.interest.findUnique.mockResolvedValue(mockInterest);
+      mockPrisma.companyAccess.findUnique.mockResolvedValue({
+        status: "ALLOW",
+      });
+      mockCheckPointBalance.mockResolvedValue({
+        canProceed: true,
+        required: 100,
+        available: 500,
+      });
+      mockConsumePointsWithOperations.mockImplementation(
+        async (
+          _companyId: string,
+          _action: string,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          operations: (tx: any) => Promise<unknown>,
+        ) => {
+          capturedTx = {
+            interest: {
+              updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+            },
+            notification: { create: vi.fn().mockResolvedValue({}) },
+          };
+          const result = await operations(capturedTx);
+          return { newBalance: 400, consumed: 100, result };
+        },
+      );
+    });
+
+    it("自動開示で連絡先を返す", async () => {
+      const { POST } = await import("@/app/api/interests/[id]/request/route");
+      const response = await POST(createPostRequest(), routeContext);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.status).toBe("CONTACT_DISCLOSED");
+      expect(data.auto).toBe(true);
+      expect(data.contact.email).toBe("test@example.com");
+    });
+
+    it("consumePointsWithOperationsにCONTACT_DISCLOSUREで呼ぶ", async () => {
+      const { POST } = await import("@/app/api/interests/[id]/request/route");
+      await POST(createPostRequest(), routeContext);
+
+      expect(mockConsumePointsWithOperations).toHaveBeenCalledWith(
+        COMPANY_ID,
+        "CONTACT_DISCLOSURE",
+        expect.any(Function),
+        INTEREST_ID,
+        expect.stringContaining("テスト太郎"),
+      );
+    });
+
+    it("ポイント不足で402を返す", async () => {
+      mockCheckPointBalance.mockResolvedValue({
+        canProceed: false,
+        required: 100,
+        available: 50,
+      });
+
+      const { POST } = await import("@/app/api/interests/[id]/request/route");
+      const response = await POST(createPostRequest(), routeContext);
+
+      expect(response.status).toBe(402);
+      expect(mockConsumePointsWithOperations).not.toHaveBeenCalled();
+    });
+
+    it("条件付きupdateManyで開示する（TOCTOU防止）", async () => {
+      const { POST } = await import("@/app/api/interests/[id]/request/route");
+      await POST(createPostRequest(), routeContext);
+
+      expect(capturedTx.interest.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: INTEREST_ID,
+          status: { in: ["EXPRESSED", "CONTACT_REQUESTED"] },
+        },
+        data: { status: "CONTACT_DISCLOSED" },
+      });
+    });
+
+    it("二重リクエストでステータス変更済みなら409（ポイント二重消費防止）", async () => {
+      mockConsumePointsWithOperations.mockImplementation(
+        async (
+          _companyId: string,
+          _action: string,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          operations: (tx: any) => Promise<unknown>,
+        ) => {
+          capturedTx = {
+            interest: {
+              updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+            },
+            notification: { create: vi.fn() },
+          };
+          return operations(capturedTx);
+        },
+      );
+
+      const { POST } = await import("@/app/api/interests/[id]/request/route");
+      const response = await POST(createPostRequest(), routeContext);
+
+      expect(response.status).toBe(409);
+      expect(capturedTx.notification.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("CONTACT_REQUESTED（通常リクエスト）", () => {
+    beforeEach(() => {
+      mockPrisma.interest.findUnique.mockResolvedValue(mockInterest);
+      mockPrisma.companyAccess.findUnique.mockResolvedValue(null); // 設定なし
+    });
+
+    it("通常の連絡先開示リクエストが成功する", async () => {
+      const { POST } = await import("@/app/api/interests/[id]/request/route");
+      const response = await POST(createPostRequest(), routeContext);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.status).toBe("CONTACT_REQUESTED");
+    });
+
+    it("条件付きupdateManyで更新する（TOCTOU防止）", async () => {
+      const { POST } = await import("@/app/api/interests/[id]/request/route");
+      await POST(createPostRequest(), routeContext);
+
+      expect(capturedTx.interest.updateMany).toHaveBeenCalledWith({
+        where: { id: INTEREST_ID, status: "EXPRESSED" },
+        data: { status: "CONTACT_REQUESTED" },
+      });
+    });
+
+    it("既にCONTACT_REQUESTEDならトランザクションをスキップ", async () => {
+      mockPrisma.interest.findUnique.mockResolvedValue({
+        ...mockInterest,
+        status: "CONTACT_REQUESTED",
+      });
+
+      const { POST } = await import("@/app/api/interests/[id]/request/route");
+      const response = await POST(createPostRequest(), routeContext);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.status).toBe("CONTACT_REQUESTED");
+      expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it("同時リクエストでステータス変更済みなら409を返す", async () => {
+      mockPrisma.$transaction.mockImplementation(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        async (callback: (tx: any) => Promise<unknown>) => {
+          capturedTx = {
+            interest: {
+              updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+            },
+            notification: { create: vi.fn() },
+          };
+          return callback(capturedTx);
+        },
+      );
+
+      const { POST } = await import("@/app/api/interests/[id]/request/route");
+      const response = await POST(createPostRequest(), routeContext);
+
+      expect(response.status).toBe(409);
+    });
+
+    it("リクエスト時に候補者に通知を送る", async () => {
+      const { POST } = await import("@/app/api/interests/[id]/request/route");
+      await POST(createPostRequest(), routeContext);
+
+      expect(capturedTx.notification.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          accountId: "user-acc-1",
+          type: "SYSTEM",
+          title: "連絡先開示のリクエスト",
+        }),
+      });
+    });
+  });
+});

--- a/src/app/api/interests/__tests__/interests.test.ts
+++ b/src/app/api/interests/__tests__/interests.test.ts
@@ -1,0 +1,379 @@
+import { Prisma } from "@prisma/client";
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mocks ──────────────────────────────────────────────────────────
+
+// Logger
+const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+vi.mock("@/lib/logger", () => ({ logger: mockLogger }));
+
+// NextAuth
+const mockGetServerSession = vi.fn();
+vi.mock("next-auth", () => ({
+  getServerSession: (...args: unknown[]) => mockGetServerSession(...args),
+}));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+
+// Prisma
+const mockPrisma = {
+  interest: {
+    findMany: vi.fn(),
+    create: vi.fn(),
+  },
+  agentProfile: {
+    findUnique: vi.fn(),
+  },
+  companyAccess: {
+    findUnique: vi.fn(),
+  },
+  notification: {
+    create: vi.fn(),
+  },
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+// Access control (uses prisma internally, but we mock it directly)
+const mockIsCompanyAccessDenied = vi.fn();
+vi.mock("@/lib/access-control", () => ({
+  isCompanyAccessDenied: (...args: unknown[]) =>
+    mockIsCompanyAccessDenied(...args),
+}));
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+const RECRUITER_ID = "rec-1";
+const COMPANY_ID = "comp-1";
+const USER_ID = "user-1";
+const AGENT_ID = "agent-1";
+const ACCOUNT_ID = "acc-user-1";
+
+function recruiterSession() {
+  return {
+    user: {
+      accountId: "acc-rec-1",
+      accountType: "RECRUITER",
+      recruiterId: RECRUITER_ID,
+      companyId: COMPANY_ID,
+      companyName: "テスト株式会社",
+      companyRole: "OWNER",
+      recruiterStatus: "ACTIVE",
+    },
+  };
+}
+
+function createGetRequest(): NextRequest {
+  return new NextRequest("http://localhost/api/interests", {
+    method: "GET",
+  });
+}
+
+function createPostRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/interests", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+describe("GET /api/interests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(recruiterSession());
+    mockIsCompanyAccessDenied.mockResolvedValue(false);
+  });
+
+  it("認証済み採用担当者は興味表明一覧を取得できる", async () => {
+    const { GET } = await import("@/app/api/interests/route");
+    mockPrisma.interest.findMany.mockResolvedValue([
+      {
+        id: "int-1",
+        recruiterId: RECRUITER_ID,
+        userId: USER_ID,
+        status: "INTERESTED",
+        createdAt: new Date(),
+        user: {
+          id: USER_ID,
+          name: "太郎",
+          email: "taro@example.com",
+          phone: "090-1234-5678",
+          avatarPath: null,
+          agent: { id: AGENT_ID, status: "PUBLIC" },
+        },
+      },
+    ]);
+
+    const res = await GET(createGetRequest());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.interests).toHaveLength(1);
+    expect(data.interests[0].id).toBe("int-1");
+  });
+
+  it("連絡先はCONTACT_DISCLOSEDの場合のみ返す", async () => {
+    const { GET } = await import("@/app/api/interests/route");
+    mockPrisma.interest.findMany.mockResolvedValue([
+      {
+        id: "int-1",
+        status: "INTERESTED",
+        user: {
+          id: USER_ID,
+          name: "太郎",
+          email: "taro@example.com",
+          phone: "090-1234-5678",
+          avatarPath: null,
+          agent: null,
+        },
+      },
+      {
+        id: "int-2",
+        status: "CONTACT_DISCLOSED",
+        user: {
+          id: "user-2",
+          name: "花子",
+          email: "hanako@example.com",
+          phone: "090-8765-4321",
+          avatarPath: null,
+          agent: null,
+        },
+      },
+    ]);
+
+    const res = await GET(createGetRequest());
+    const data = await res.json();
+
+    // INTERESTED → メール・電話はnull
+    expect(data.interests[0].user.email).toBeNull();
+    expect(data.interests[0].user.phone).toBeNull();
+
+    // CONTACT_DISCLOSED → メール・電話が含まれる
+    expect(data.interests[1].user.email).toBe("hanako@example.com");
+    expect(data.interests[1].user.phone).toBe("090-8765-4321");
+  });
+
+  it("未認証の場合は401を返す", async () => {
+    const { GET } = await import("@/app/api/interests/route");
+    mockGetServerSession.mockResolvedValue(null);
+
+    const res = await GET(createGetRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("recruiterIdを持たないセッションは403を返す", async () => {
+    const { GET } = await import("@/app/api/interests/route");
+    mockGetServerSession.mockResolvedValue({
+      user: {
+        accountId: "acc-1",
+        accountType: "USER",
+        userId: USER_ID,
+      },
+    });
+
+    const res = await GET(createGetRequest());
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("POST /api/interests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(recruiterSession());
+    mockIsCompanyAccessDenied.mockResolvedValue(false);
+    mockPrisma.agentProfile.findUnique.mockResolvedValue({
+      id: AGENT_ID,
+      userId: USER_ID,
+      status: "PUBLIC",
+      user: { id: USER_ID, accountId: ACCOUNT_ID },
+    });
+    mockPrisma.interest.create.mockResolvedValue({
+      id: "int-new",
+      recruiterId: RECRUITER_ID,
+      userId: USER_ID,
+      agentId: AGENT_ID,
+      message: null,
+      status: "INTERESTED",
+      user: { id: USER_ID, name: "太郎" },
+    });
+    mockPrisma.notification.create.mockResolvedValue({ id: "notif-1" });
+  });
+
+  // ── バリデーション ────────────────────────────────────────
+
+  it("agentIdが空の場合は400を返す", async () => {
+    const { POST } = await import("@/app/api/interests/route");
+    const res = await POST(createPostRequest({ agentId: "" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("agentIdがない場合は400を返す", async () => {
+    const { POST } = await import("@/app/api/interests/route");
+    const res = await POST(createPostRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("messageが2000文字を超える場合は400を返す", async () => {
+    const { POST } = await import("@/app/api/interests/route");
+    const res = await POST(
+      createPostRequest({
+        agentId: AGENT_ID,
+        message: "a".repeat(2001),
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  // ── 正常系 ────────────────────────────────────────────────
+
+  it("正常に興味表明でき201を返す", async () => {
+    const { POST } = await import("@/app/api/interests/route");
+    const res = await POST(createPostRequest({ agentId: AGENT_ID }));
+
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.interest.id).toBe("int-new");
+    expect(data.interest.user.name).toBe("太郎");
+  });
+
+  it("メッセージ付きで興味表明できる", async () => {
+    const { POST } = await import("@/app/api/interests/route");
+    const res = await POST(
+      createPostRequest({
+        agentId: AGENT_ID,
+        message: "ぜひお話ししたいです",
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    expect(mockPrisma.interest.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          message: "ぜひお話ししたいです",
+        }),
+      }),
+    );
+  });
+
+  it("通知が正しく作成される", async () => {
+    const { POST } = await import("@/app/api/interests/route");
+    await POST(createPostRequest({ agentId: AGENT_ID }));
+
+    expect(mockPrisma.notification.create).toHaveBeenCalledWith({
+      data: {
+        accountId: ACCOUNT_ID,
+        type: "NEW_CANDIDATE_MATCH",
+        title: "企業からの興味表明",
+        body: "テスト株式会社があなたに興味を持っています",
+        data: {
+          interestId: "int-new",
+          recruiterId: RECRUITER_ID,
+          companyName: "テスト株式会社",
+        },
+      },
+    });
+  });
+
+  // ── エラー系 ──────────────────────────────────────────────
+
+  it("エージェントが存在しない場合は404を返す", async () => {
+    const { POST } = await import("@/app/api/interests/route");
+    mockPrisma.agentProfile.findUnique.mockResolvedValue(null);
+
+    const res = await POST(createPostRequest({ agentId: "nonexistent" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("エージェントが非公開の場合は403を返す", async () => {
+    const { POST } = await import("@/app/api/interests/route");
+    mockPrisma.agentProfile.findUnique.mockResolvedValue({
+      id: AGENT_ID,
+      userId: USER_ID,
+      status: "DRAFT",
+      user: { id: USER_ID, accountId: ACCOUNT_ID },
+    });
+
+    const res = await POST(createPostRequest({ agentId: AGENT_ID }));
+    expect(res.status).toBe(403);
+  });
+
+  it("企業アクセスが拒否されている場合は403を返す", async () => {
+    const { POST } = await import("@/app/api/interests/route");
+    mockIsCompanyAccessDenied.mockResolvedValue(true);
+
+    const res = await POST(createPostRequest({ agentId: AGENT_ID }));
+    expect(res.status).toBe(403);
+    expect(mockIsCompanyAccessDenied).toHaveBeenCalledWith(COMPANY_ID, USER_ID);
+  });
+
+  it("重複興味表明（P2002）の場合は409を返す", async () => {
+    const { POST } = await import("@/app/api/interests/route");
+    mockPrisma.interest.create.mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+        code: "P2002",
+        clientVersion: "6.0.0",
+      }),
+    );
+
+    const res = await POST(createPostRequest({ agentId: AGENT_ID }));
+    expect(res.status).toBe(409);
+    const data = await res.json();
+    expect(data.error).toContain("興味表明済み");
+  });
+
+  it("P2002以外のPrismaエラーは500を返す", async () => {
+    const { POST } = await import("@/app/api/interests/route");
+    mockPrisma.interest.create.mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError("Connection error", {
+        code: "P1001",
+        clientVersion: "6.0.0",
+      }),
+    );
+
+    const res = await POST(createPostRequest({ agentId: AGENT_ID }));
+    expect(res.status).toBe(500);
+  });
+
+  it("未認証の場合は401を返す", async () => {
+    const { POST } = await import("@/app/api/interests/route");
+    mockGetServerSession.mockResolvedValue(null);
+
+    const res = await POST(createPostRequest({ agentId: AGENT_ID }));
+    expect(res.status).toBe(401);
+  });
+
+  it("重複チェックではなくDB制約で重複を防止する（TOCTOU安全）", async () => {
+    const { POST } = await import("@/app/api/interests/route");
+
+    // findUniqueが呼ばれていないことを検証（findManyはGET用）
+    await POST(createPostRequest({ agentId: AGENT_ID }));
+
+    // interest.findUniqueは呼ばれず、直接createが呼ばれる
+    expect(mockPrisma.interest.create).toHaveBeenCalledTimes(1);
+    // agentProfile.findUniqueはエージェント存在確認用で正当
+    expect(mockPrisma.agentProfile.findUnique).toHaveBeenCalledTimes(1);
+  });
+
+  it("companyNameがない場合はデフォルト値で通知を作成する", async () => {
+    const { POST } = await import("@/app/api/interests/route");
+    mockGetServerSession.mockResolvedValue({
+      user: {
+        ...recruiterSession().user,
+        companyName: undefined,
+      },
+    });
+
+    await POST(createPostRequest({ agentId: AGENT_ID }));
+
+    expect(mockPrisma.notification.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          body: "企業があなたに興味を持っています",
+          data: expect.objectContaining({
+            companyName: "企業",
+          }),
+        }),
+      }),
+    );
+  });
+});

--- a/src/app/api/interests/route.ts
+++ b/src/app/api/interests/route.ts
@@ -34,6 +34,7 @@ export const GET = withRecruiterAuth(async (req, session) => {
       },
     },
     orderBy: { createdAt: "desc" },
+    take: 200,
   });
 
   // 連絡先は開示済みの場合のみ返す

--- a/src/app/api/internal/analysis-callback/__tests__/analysis-callback.test.ts
+++ b/src/app/api/internal/analysis-callback/__tests__/analysis-callback.test.ts
@@ -1,0 +1,407 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Logger モック
+const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+vi.mock("@/lib/logger", () => ({ logger: mockLogger }));
+
+// Prisma モック
+const mockPrisma = {
+  document: { update: vi.fn() },
+  fragment: { createMany: vi.fn() },
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+// テスト用定数
+const API_SECRET = "test-secret-key";
+const DOC_ID = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d";
+const USER_ID = "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e";
+
+function createRequest(body: unknown, apiKey?: string): NextRequest {
+  return new NextRequest("http://localhost/api/internal/analysis-callback", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(apiKey ? { "x-api-key": apiKey } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/internal/analysis-callback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("ANALYSIS_CALLBACK_SECRET", API_SECRET);
+    mockPrisma.document.update.mockResolvedValue({});
+    mockPrisma.fragment.createMany.mockResolvedValue({ count: 0 });
+  });
+
+  describe("認証", () => {
+    it("x-api-keyがない場合は401を返す", async () => {
+      const { POST } = await import(
+        "@/app/api/internal/analysis-callback/route"
+      );
+      const req = createRequest({ documentId: DOC_ID, userId: USER_ID });
+
+      const res = await POST(req);
+      expect(res.status).toBe(401);
+      const data = await res.json();
+      expect(data.error).toBe("Unauthorized");
+    });
+
+    it("x-api-keyが不正な場合は401を返す", async () => {
+      const { POST } = await import(
+        "@/app/api/internal/analysis-callback/route"
+      );
+      const req = createRequest(
+        { documentId: DOC_ID, userId: USER_ID },
+        "wrong-key",
+      );
+
+      const res = await POST(req);
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("バリデーション", () => {
+    it("documentIdが欠落している場合は400を返す", async () => {
+      const { POST } = await import(
+        "@/app/api/internal/analysis-callback/route"
+      );
+      const req = createRequest({ userId: USER_ID }, API_SECRET);
+
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+    });
+
+    it("userIdが欠落している場合は400を返す", async () => {
+      const { POST } = await import(
+        "@/app/api/internal/analysis-callback/route"
+      );
+      const req = createRequest({ documentId: DOC_ID }, API_SECRET);
+
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+    });
+
+    it("documentIdがUUID形式でない場合は400を返す", async () => {
+      const { POST } = await import(
+        "@/app/api/internal/analysis-callback/route"
+      );
+      const req = createRequest(
+        { documentId: "not-a-uuid", userId: USER_ID },
+        API_SECRET,
+      );
+
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+    });
+
+    it("fragmentsのcontentが空文字の場合は400を返す", async () => {
+      const { POST } = await import(
+        "@/app/api/internal/analysis-callback/route"
+      );
+      const req = createRequest(
+        {
+          documentId: DOC_ID,
+          userId: USER_ID,
+          fragments: [{ type: "FACT", content: "", skills: [], keywords: [] }],
+        },
+        API_SECRET,
+      );
+
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+    });
+
+    it("未知のプロパティがある場合は400を返す（strict mode）", async () => {
+      const { POST } = await import(
+        "@/app/api/internal/analysis-callback/route"
+      );
+      const req = createRequest(
+        {
+          documentId: DOC_ID,
+          userId: USER_ID,
+          maliciousField: "DROP TABLE",
+        },
+        API_SECRET,
+      );
+
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+    });
+
+    it("fragmentsが500件を超える場合は400を返す", async () => {
+      const { POST } = await import(
+        "@/app/api/internal/analysis-callback/route"
+      );
+      const fragments = Array.from({ length: 501 }, (_, i) => ({
+        type: "FACT",
+        content: `Fragment ${i}`,
+        skills: [],
+        keywords: [],
+      }));
+      const req = createRequest(
+        { documentId: DOC_ID, userId: USER_ID, fragments },
+        API_SECRET,
+      );
+
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+    });
+
+    it("バリデーションエラー時に警告ログを出力する", async () => {
+      const { POST } = await import(
+        "@/app/api/internal/analysis-callback/route"
+      );
+      const req = createRequest({ invalid: true }, API_SECRET);
+
+      await POST(req);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        "Analysis callback validation failed",
+        expect.objectContaining({ errors: expect.any(Array) }),
+      );
+    });
+  });
+
+  describe("エラーコールバック", () => {
+    it("errorフィールドがある場合はドキュメントをFAILEDに更新する", async () => {
+      const { POST } = await import(
+        "@/app/api/internal/analysis-callback/route"
+      );
+      const req = createRequest(
+        {
+          documentId: DOC_ID,
+          userId: USER_ID,
+          error: "Lambda processing failed",
+        },
+        API_SECRET,
+      );
+
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.status).toBe("FAILED");
+
+      expect(mockPrisma.document.update).toHaveBeenCalledWith({
+        where: { id: DOC_ID },
+        data: {
+          analysisStatus: "FAILED",
+          analysisError: "Lambda processing failed",
+        },
+      });
+
+      // フラグメントは作成しない
+      expect(mockPrisma.fragment.createMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("成功コールバック", () => {
+    it("フラグメントを作成してドキュメントをCOMPLETEDに更新する", async () => {
+      const { POST } = await import(
+        "@/app/api/internal/analysis-callback/route"
+      );
+      mockPrisma.fragment.createMany.mockResolvedValue({ count: 2 });
+
+      const req = createRequest(
+        {
+          documentId: DOC_ID,
+          userId: USER_ID,
+          fragments: [
+            {
+              type: "FACT",
+              content: "5年間のTypeScript経験",
+              skills: ["TypeScript"],
+              keywords: ["経験"],
+            },
+            {
+              type: "SKILL_USAGE",
+              content: "Reactでフロントエンド開発",
+              skills: ["React"],
+              keywords: ["フロントエンド"],
+            },
+          ],
+        },
+        API_SECRET,
+      );
+
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.status).toBe("COMPLETED");
+      expect(data.fragmentsCount).toBe(2);
+
+      expect(mockPrisma.fragment.createMany).toHaveBeenCalledWith({
+        data: [
+          {
+            userId: USER_ID,
+            type: "FACT",
+            content: "5年間のTypeScript経験",
+            skills: ["TypeScript"],
+            keywords: ["経験"],
+            sourceType: "DOCUMENT",
+            sourceId: DOC_ID,
+          },
+          {
+            userId: USER_ID,
+            type: "SKILL_USAGE",
+            content: "Reactでフロントエンド開発",
+            skills: ["React"],
+            keywords: ["フロントエンド"],
+            sourceType: "DOCUMENT",
+            sourceId: DOC_ID,
+          },
+        ],
+      });
+
+      expect(mockPrisma.document.update).toHaveBeenCalledWith({
+        where: { id: DOC_ID },
+        data: expect.objectContaining({
+          analysisStatus: "COMPLETED",
+          summary: "2件の記憶のかけらを抽出しました",
+        }),
+      });
+    });
+
+    it("不明なフラグメントtypeはFACTにフォールバックする", async () => {
+      const { POST } = await import(
+        "@/app/api/internal/analysis-callback/route"
+      );
+      mockPrisma.fragment.createMany.mockResolvedValue({ count: 1 });
+
+      const req = createRequest(
+        {
+          documentId: DOC_ID,
+          userId: USER_ID,
+          fragments: [
+            {
+              type: "UNKNOWN_TYPE",
+              content: "何かの内容",
+              skills: [],
+              keywords: [],
+            },
+          ],
+        },
+        API_SECRET,
+      );
+
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+
+      expect(mockPrisma.fragment.createMany).toHaveBeenCalledWith({
+        data: [expect.objectContaining({ type: "FACT" })],
+      });
+    });
+
+    it("フラグメントが空の場合はcreateMany呼び出しをスキップする", async () => {
+      const { POST } = await import(
+        "@/app/api/internal/analysis-callback/route"
+      );
+      const req = createRequest(
+        { documentId: DOC_ID, userId: USER_ID, fragments: [] },
+        API_SECRET,
+      );
+
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.fragmentsCount).toBe(0);
+
+      expect(mockPrisma.fragment.createMany).not.toHaveBeenCalled();
+      expect(mockPrisma.document.update).toHaveBeenCalledWith({
+        where: { id: DOC_ID },
+        data: expect.objectContaining({
+          summary: "記憶のかけらが見つかりませんでした",
+        }),
+      });
+    });
+
+    it("summaryが指定されている場合はそれを使用する", async () => {
+      const { POST } = await import(
+        "@/app/api/internal/analysis-callback/route"
+      );
+      mockPrisma.fragment.createMany.mockResolvedValue({ count: 1 });
+
+      const req = createRequest(
+        {
+          documentId: DOC_ID,
+          userId: USER_ID,
+          fragments: [
+            { type: "FACT", content: "テスト", skills: [], keywords: [] },
+          ],
+          summary: "カスタムサマリー",
+        },
+        API_SECRET,
+      );
+
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+
+      expect(mockPrisma.document.update).toHaveBeenCalledWith({
+        where: { id: DOC_ID },
+        data: expect.objectContaining({ summary: "カスタムサマリー" }),
+      });
+    });
+
+    it("skillsとkeywordsがデフォルトで空配列になる", async () => {
+      const { POST } = await import(
+        "@/app/api/internal/analysis-callback/route"
+      );
+      mockPrisma.fragment.createMany.mockResolvedValue({ count: 1 });
+
+      const req = createRequest(
+        {
+          documentId: DOC_ID,
+          userId: USER_ID,
+          fragments: [{ type: "FACT", content: "テスト内容" }],
+        },
+        API_SECRET,
+      );
+
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+
+      expect(mockPrisma.fragment.createMany).toHaveBeenCalledWith({
+        data: [expect.objectContaining({ skills: [], keywords: [] })],
+      });
+    });
+
+    it("全有効なFragmentTypeが正しくマッピングされる", async () => {
+      const { POST } = await import(
+        "@/app/api/internal/analysis-callback/route"
+      );
+      const validTypes = [
+        "ACHIEVEMENT",
+        "ACTION",
+        "CHALLENGE",
+        "LEARNING",
+        "VALUE",
+        "EMOTION",
+        "FACT",
+        "SKILL_USAGE",
+      ];
+      const fragments = validTypes.map((type) => ({
+        type,
+        content: `${type}の内容`,
+        skills: [],
+        keywords: [],
+      }));
+      mockPrisma.fragment.createMany.mockResolvedValue({
+        count: validTypes.length,
+      });
+
+      const req = createRequest(
+        { documentId: DOC_ID, userId: USER_ID, fragments },
+        API_SECRET,
+      );
+
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+
+      const callArgs = mockPrisma.fragment.createMany.mock.calls[0][0];
+      for (let i = 0; i < validTypes.length; i++) {
+        expect(callArgs.data[i].type).toBe(validTypes[i]);
+      }
+    });
+  });
+});

--- a/src/app/api/interview/[id]/chat/__tests__/interview-chat.test.ts
+++ b/src/app/api/interview/[id]/chat/__tests__/interview-chat.test.ts
@@ -1,0 +1,491 @@
+/**
+ * 面談チャット（エージェント会話）API テスト
+ *
+ * 課金を伴うクリティカルパス:
+ * - 新規セッション作成時に CONVERSATION (1pt) を消費
+ * - 既存セッションがあればポイント消費なし
+ * - 同時リクエストによる二重課金を防止
+ */
+
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── モック定義 ──────────────────────────────────────
+
+const mockGetServerSession = vi.fn();
+vi.mock("next-auth", () => ({
+  getServerSession: () => mockGetServerSession(),
+}));
+vi.mock("@/lib/auth", () => ({
+  authOptions: {},
+}));
+
+// Prisma トランザクション用クライアント
+const mockTxClient = {
+  session: {
+    findFirst: vi.fn(),
+    create: vi.fn(),
+  },
+};
+
+const mockPrisma = {
+  agentProfile: { findUnique: vi.fn() },
+  jobPosting: { findFirst: vi.fn() },
+  session: { findFirst: vi.fn() },
+  message: { create: vi.fn() },
+  fragment: { findMany: vi.fn() },
+  messageReference: { createMany: vi.fn() },
+  companyAccess: { findUnique: vi.fn() },
+  $transaction: vi.fn(),
+};
+vi.mock("@/lib/prisma", () => ({
+  prisma: mockPrisma,
+}));
+
+// consumePointsWithOperations モック
+const mockConsumePointsWithOperations = vi.fn();
+vi.mock("@/lib/points", () => ({
+  consumePointsWithOperations: (...args: unknown[]) =>
+    mockConsumePointsWithOperations(...args),
+}));
+
+// OpenAI モック
+const mockGenerateChatResponse = vi.fn();
+const mockGenerateFollowUpQuestions = vi.fn();
+vi.mock("@/lib/openai", () => ({
+  generateChatResponse: (...args: unknown[]) =>
+    mockGenerateChatResponse(...args),
+  generateFollowUpQuestions: (...args: unknown[]) =>
+    mockGenerateFollowUpQuestions(...args),
+}));
+
+// coverage モック
+vi.mock("@/lib/coverage", () => ({
+  calculateCoverage: () => ({
+    percentage: 50,
+    isComplete: false,
+    categories: [
+      { label: "スキル", fulfilled: true, current: 2, required: 1 },
+      { label: "経験", fulfilled: false, current: 0, required: 1 },
+    ],
+  }),
+}));
+
+// logger モック
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// ── テストデータ ──────────────────────────────────────
+
+const recruiterSession = {
+  user: {
+    accountId: "account-r1",
+    accountType: "RECRUITER",
+    recruiterId: "recruiter-1",
+    companyId: "company-1",
+    companyRole: "OWNER",
+    recruiterStatus: "ACTIVE",
+  },
+};
+
+const mockAgent = {
+  id: "agent-1",
+  userId: "user-1",
+  systemPrompt: "あなたはテスト太郎のAIエージェントです。",
+  status: "PUBLIC",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  user: {
+    id: "user-1",
+    accountId: "account-u1",
+    name: "テスト太郎",
+    email: "taro@example.com",
+    phone: null,
+    avatarPath: null,
+  },
+};
+
+const mockExistingSession = {
+  id: "session-1",
+  sessionType: "RECRUITER_AGENT_CHAT",
+  recruiterId: "recruiter-1",
+  agentId: "agent-1",
+  createdAt: new Date(),
+  messages: [
+    {
+      id: "msg-1",
+      sessionId: "session-1",
+      senderType: "RECRUITER",
+      senderId: "recruiter-1",
+      content: "前回の質問です",
+      createdAt: new Date("2026-01-01"),
+    },
+    {
+      id: "msg-2",
+      sessionId: "session-1",
+      senderType: "AI",
+      senderId: null,
+      content: "前回のAI回答です",
+      createdAt: new Date("2026-01-01"),
+    },
+  ],
+};
+
+const mockNewSession = {
+  id: "session-new",
+  sessionType: "RECRUITER_AGENT_CHAT",
+  recruiterId: "recruiter-1",
+  agentId: "agent-1",
+  createdAt: new Date(),
+  messages: [],
+};
+
+const mockFragments = [
+  {
+    id: "frag-1",
+    type: "SKILL_USAGE",
+    content: "TypeScriptでフロントエンド開発を3年間担当",
+    skills: ["TypeScript", "React"],
+    keywords: ["フロントエンド"],
+  },
+];
+
+const mockAiMessage = {
+  id: "ai-msg-1",
+  sessionId: "session-1",
+  senderType: "AI",
+  content: "テスト太郎はTypeScriptの経験があります。",
+  createdAt: new Date(),
+};
+
+// ── ヘルパー ──────────────────────────────────────
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/interview/agent-1/chat", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+function setupDefaultMocks() {
+  mockGetServerSession.mockResolvedValue(recruiterSession);
+  mockPrisma.agentProfile.findUnique.mockResolvedValue(mockAgent);
+  mockPrisma.companyAccess.findUnique.mockResolvedValue(null); // アクセス拒否なし
+  mockPrisma.fragment.findMany.mockResolvedValue(mockFragments);
+  mockPrisma.message.create.mockResolvedValue(mockAiMessage);
+  mockPrisma.messageReference.createMany.mockResolvedValue({ count: 1 });
+  mockGenerateChatResponse.mockResolvedValue(
+    "テスト太郎はTypeScriptの経験があります。",
+  );
+}
+
+// ── テスト ──────────────────────────────────────
+
+describe("POST /api/interview/[id]/chat", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("正常系", () => {
+    it("既存セッションがある場合、ポイント消費なしでAI応答を返す", async () => {
+      setupDefaultMocks();
+      mockPrisma.session.findFirst.mockResolvedValue(mockExistingSession);
+
+      const { POST } = await import("@/app/api/interview/[id]/chat/route");
+      const request = makeRequest({
+        message: "TypeScriptの経験はありますか？",
+      });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: "agent-1" }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.message).toBe("テスト太郎はTypeScriptの経験があります。");
+      // ポイント消費は呼ばれない
+      expect(mockConsumePointsWithOperations).not.toHaveBeenCalled();
+    });
+
+    it("新規セッション作成時にポイントを消費してセッションを作成する", async () => {
+      setupDefaultMocks();
+      mockPrisma.session.findFirst.mockResolvedValue(null); // 既存セッションなし
+      mockConsumePointsWithOperations.mockImplementation(
+        async (
+          _companyId: string,
+          _action: string,
+          operations: (tx: typeof mockTxClient) => Promise<unknown>,
+        ) => {
+          // tx内で既存セッションなし（正常パス）
+          mockTxClient.session.findFirst.mockResolvedValue(null);
+          mockTxClient.session.create.mockResolvedValue(mockNewSession);
+          const result = await operations(mockTxClient);
+          return { newBalance: 99, consumed: 1, result };
+        },
+      );
+
+      const { POST } = await import("@/app/api/interview/[id]/chat/route");
+      const request = makeRequest({ message: "自己紹介をお願いします" });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: "agent-1" }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.message).toBeDefined();
+      expect(mockConsumePointsWithOperations).toHaveBeenCalledWith(
+        "company-1",
+        "CONVERSATION",
+        expect.any(Function),
+        undefined,
+        "エージェント会話: テスト太郎",
+      );
+      // トランザクション内でセッション作成が呼ばれる
+      expect(mockTxClient.session.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            sessionType: "RECRUITER_AGENT_CHAT",
+            recruiterId: "recruiter-1",
+            agentId: "agent-1",
+          }),
+        }),
+      );
+    });
+
+    it("AI応答にフラグメント参照情報が含まれる", async () => {
+      setupDefaultMocks();
+      mockPrisma.session.findFirst.mockResolvedValue(mockExistingSession);
+
+      const { POST } = await import("@/app/api/interview/[id]/chat/route");
+      // "TypeScript" はフラグメントのスキルに一致するのでスコアが付く
+      const request = makeRequest({
+        message: "TypeScriptの経験について教えてください",
+      });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: "agent-1" }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.references).toBeDefined();
+      expect(Array.isArray(data.references)).toBe(true);
+      // TypeScript を含むメッセージなので関連フラグメントが見つかる
+      if (data.references.length > 0) {
+        expect(data.references[0]).toHaveProperty("id");
+        expect(data.references[0]).toHaveProperty("type");
+        expect(data.references[0]).toHaveProperty("skills");
+      }
+    });
+
+    it("求人情報を指定した場合、フォローアップ質問が返る", async () => {
+      setupDefaultMocks();
+      mockPrisma.session.findFirst.mockResolvedValue(mockExistingSession);
+      mockPrisma.jobPosting.findFirst.mockResolvedValue({
+        id: "job-1",
+        recruiterId: "recruiter-1",
+        title: "フロントエンドエンジニア",
+        description: "React/TypeScript開発",
+        skills: ["React", "TypeScript"],
+        experienceLevel: "MID",
+      });
+      mockGenerateFollowUpQuestions.mockResolvedValue([
+        "チーム規模はどのくらいでしたか？",
+        "技術選定に携わった経験はありますか？",
+      ]);
+
+      const { POST } = await import("@/app/api/interview/[id]/chat/route");
+      const request = makeRequest({
+        message: "TypeScriptの経験はありますか？",
+        jobId: "job-1",
+      });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: "agent-1" }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.followUps).toEqual([
+        "チーム規模はどのくらいでしたか？",
+        "技術選定に携わった経験はありますか？",
+      ]);
+    });
+
+    it("フォローアップ質問の生成失敗は無視される", async () => {
+      setupDefaultMocks();
+      mockPrisma.session.findFirst.mockResolvedValue(mockExistingSession);
+      mockPrisma.jobPosting.findFirst.mockResolvedValue({
+        id: "job-1",
+        recruiterId: "recruiter-1",
+        title: "エンジニア",
+        description: "開発",
+        skills: [],
+        experienceLevel: "MID",
+      });
+      mockGenerateFollowUpQuestions.mockRejectedValue(
+        new Error("OpenAI error"),
+      );
+
+      const { POST } = await import("@/app/api/interview/[id]/chat/route");
+      const request = makeRequest({
+        message: "経験を教えてください",
+        jobId: "job-1",
+      });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: "agent-1" }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.followUps).toEqual([]);
+    });
+  });
+
+  describe("同時リクエスト保護", () => {
+    it("トランザクション内で既存セッションが検出された場合、ポイント消費せず既存セッションを使用する", async () => {
+      setupDefaultMocks();
+      // 初回チェック: セッションなし
+      mockPrisma.session.findFirst
+        .mockResolvedValueOnce(null)
+        // DuplicateSessionError後の再取得
+        .mockResolvedValueOnce(mockExistingSession);
+
+      mockConsumePointsWithOperations.mockImplementation(
+        async (
+          _companyId: string,
+          _action: string,
+          operations: (tx: typeof mockTxClient) => Promise<unknown>,
+        ) => {
+          // tx内で既存セッション発見 → DuplicateSessionErrorをスロー
+          mockTxClient.session.findFirst.mockResolvedValue(mockExistingSession);
+          return operations(mockTxClient);
+          // DuplicateSessionError がスローされ、トランザクションはロールバック
+        },
+      );
+
+      const { POST } = await import("@/app/api/interview/[id]/chat/route");
+      const request = makeRequest({ message: "テストメッセージ" });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: "agent-1" }),
+      });
+      const data = await response.json();
+
+      // 正常にレスポンスが返る（既存セッションで続行）
+      expect(response.status).toBe(200);
+      expect(data.message).toBeDefined();
+      // セッション作成は呼ばれない（既存セッションを使用）
+      expect(mockTxClient.session.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("異常系", () => {
+    it("未認証の場合401を返す", async () => {
+      mockGetServerSession.mockResolvedValue(null);
+
+      const { POST } = await import("@/app/api/interview/[id]/chat/route");
+      const request = makeRequest({ message: "テスト" });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: "agent-1" }),
+      });
+
+      expect(response.status).toBe(401);
+    });
+
+    it("メッセージが空の場合400を返す", async () => {
+      mockGetServerSession.mockResolvedValue(recruiterSession);
+
+      const { POST } = await import("@/app/api/interview/[id]/chat/route");
+      const request = makeRequest({ message: "" });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: "agent-1" }),
+      });
+
+      expect(response.status).toBe(400);
+    });
+
+    it("エージェントが存在しない場合404を返す", async () => {
+      mockGetServerSession.mockResolvedValue(recruiterSession);
+      mockPrisma.agentProfile.findUnique.mockResolvedValue(null);
+
+      const { POST } = await import("@/app/api/interview/[id]/chat/route");
+      const request = makeRequest({ message: "テスト" });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: "nonexistent" }),
+      });
+
+      expect(response.status).toBe(404);
+    });
+
+    it("エージェントが非公開の場合403を返す", async () => {
+      mockGetServerSession.mockResolvedValue(recruiterSession);
+      mockPrisma.agentProfile.findUnique.mockResolvedValue({
+        ...mockAgent,
+        status: "PRIVATE",
+      });
+
+      const { POST } = await import("@/app/api/interview/[id]/chat/route");
+      const request = makeRequest({ message: "テスト" });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: "agent-1" }),
+      });
+
+      expect(response.status).toBe(403);
+    });
+
+    it("会社のアクセスが拒否されている場合403を返す", async () => {
+      mockGetServerSession.mockResolvedValue(recruiterSession);
+      mockPrisma.agentProfile.findUnique.mockResolvedValue(mockAgent);
+      mockPrisma.companyAccess.findUnique.mockResolvedValue({
+        status: "DENY",
+      });
+
+      const { POST } = await import("@/app/api/interview/[id]/chat/route");
+      const request = makeRequest({ message: "テスト" });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: "agent-1" }),
+      });
+
+      expect(response.status).toBe(403);
+    });
+
+    it("指定された求人が存在しない場合404を返す", async () => {
+      setupDefaultMocks();
+      mockPrisma.session.findFirst.mockResolvedValue(mockExistingSession);
+      mockPrisma.jobPosting.findFirst.mockResolvedValue(null);
+
+      const { POST } = await import("@/app/api/interview/[id]/chat/route");
+      const request = makeRequest({
+        message: "テスト",
+        jobId: "nonexistent-job",
+      });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: "agent-1" }),
+      });
+
+      expect(response.status).toBe(404);
+    });
+
+    it("ポイント不足の場合、consumePointsWithOperationsのエラーが伝播する", async () => {
+      setupDefaultMocks();
+      mockPrisma.session.findFirst.mockResolvedValue(null); // 新規セッション
+
+      const { InsufficientPointsError } = await import("@/lib/errors");
+      mockConsumePointsWithOperations.mockRejectedValue(
+        new InsufficientPointsError(1, 0),
+      );
+
+      const { POST } = await import("@/app/api/interview/[id]/chat/route");
+      const request = makeRequest({ message: "テスト" });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: "agent-1" }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(402);
+      expect(data.code).toBe("INSUFFICIENT_POINTS");
+    });
+  });
+});

--- a/src/app/api/interview/[id]/chat/route.ts
+++ b/src/app/api/interview/[id]/chat/route.ts
@@ -23,7 +23,7 @@ class DuplicateSessionError extends Error {
 type RouteContext = { params: Promise<{ id: string }> };
 
 const chatSchema = z.object({
-  message: z.string().min(1, "メッセージは必須です"),
+  message: z.string().min(1, "メッセージは必須です").max(5000),
   jobId: z.string().optional(),
   missingInfo: z.array(z.string()).optional(),
 });

--- a/src/app/api/interview/[id]/chat/route.ts
+++ b/src/app/api/interview/[id]/chat/route.ts
@@ -130,6 +130,13 @@ export const POST = withRecruiterAuth<RouteContext>(
 
     const fragments = await prisma.fragment.findMany({
       where: { userId: agent.userId },
+      select: {
+        id: true,
+        type: true,
+        content: true,
+        skills: true,
+        keywords: true,
+      },
     });
 
     // 質問に関連するフラグメントをスコアリング

--- a/src/app/api/interview/[id]/chat/route.ts
+++ b/src/app/api/interview/[id]/chat/route.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { isCompanyAccessDenied } from "@/lib/access-control";
 import { withRecruiterAuth } from "@/lib/api-utils";
 import { calculateCoverage } from "@/lib/coverage";
-import { ForbiddenError, NotFoundError } from "@/lib/errors";
+import { ForbiddenError, NotFoundError, ValidationError } from "@/lib/errors";
 import { generateChatResponse, generateFollowUpQuestions } from "@/lib/openai";
 import { consumePointsWithOperations } from "@/lib/points";
 import { prisma } from "@/lib/prisma";
@@ -23,7 +23,6 @@ export const POST = withRecruiterAuth<RouteContext>(
     const parsed = chatSchema.safeParse(rawBody);
 
     if (!parsed.success) {
-      const { ValidationError } = await import("@/lib/errors");
       throw new ValidationError("入力内容に問題があります", {
         fields: parsed.error.flatten().fieldErrors,
       });

--- a/src/app/api/interview/[id]/evaluation/__tests__/evaluation.test.ts
+++ b/src/app/api/interview/[id]/evaluation/__tests__/evaluation.test.ts
@@ -1,0 +1,378 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// NextAuth モック
+const mockGetServerSession = vi.fn();
+vi.mock("next-auth", () => ({
+  getServerSession: () => mockGetServerSession(),
+}));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+
+// Logger モック
+const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+vi.mock("@/lib/logger", () => ({ logger: mockLogger }));
+
+// アクセス制御モック
+const mockIsCompanyAccessDenied = vi.fn();
+vi.mock("@/lib/access-control", () => ({
+  isCompanyAccessDenied: (...args: unknown[]) =>
+    mockIsCompanyAccessDenied(...args),
+}));
+
+// Prisma モック
+const mockPrisma = {
+  agentProfile: { findUnique: vi.fn() },
+  session: { findFirst: vi.fn() },
+  interviewEvaluation: { findUnique: vi.fn(), upsert: vi.fn() },
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+const AGENT_ID = "agent-001";
+const RECRUITER_ID = "recruiter-001";
+const COMPANY_ID = "company-001";
+const SESSION_ID = "session-001";
+const USER_ID = "user-001";
+
+const recruiterSession = {
+  user: {
+    accountId: "acc-1",
+    recruiterId: RECRUITER_ID,
+    companyId: COMPANY_ID,
+    accountType: "RECRUITER",
+    companyRole: "ADMIN",
+    recruiterStatus: "ACTIVE",
+  },
+};
+
+const routeContext = { params: Promise.resolve({ id: AGENT_ID }) };
+
+const mockAgent = {
+  userId: USER_ID,
+  status: "PUBLIC",
+};
+
+const mockChatSession = {
+  id: SESSION_ID,
+  agentId: AGENT_ID,
+  recruiterId: RECRUITER_ID,
+  sessionType: "RECRUITER_AGENT_CHAT",
+};
+
+const validEvaluationBody = {
+  overallRating: 4,
+  technicalRating: 3,
+  communicationRating: 5,
+  cultureRating: 4,
+  comment: "優秀な候補者です。",
+};
+
+const mockEvaluation = {
+  id: "eval-001",
+  sessionId: SESSION_ID,
+  recruiterId: RECRUITER_ID,
+  ...validEvaluationBody,
+};
+
+function createGetRequest(): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/interview/${AGENT_ID}/evaluation`,
+    { method: "GET" },
+  );
+}
+
+function createPostRequest(body: unknown): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/interview/${AGENT_ID}/evaluation`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+describe("GET /api/interview/[id]/evaluation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(recruiterSession);
+    mockIsCompanyAccessDenied.mockResolvedValue(false);
+    mockPrisma.agentProfile.findUnique.mockResolvedValue(mockAgent);
+    mockPrisma.session.findFirst.mockResolvedValue(mockChatSession);
+    mockPrisma.interviewEvaluation.findUnique.mockResolvedValue(mockEvaluation);
+  });
+
+  describe("認証", () => {
+    it("未認証の場合は401を返す", async () => {
+      mockGetServerSession.mockResolvedValue(null);
+      const { GET } = await import("@/app/api/interview/[id]/evaluation/route");
+
+      const res = await GET(createGetRequest(), routeContext);
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("エージェント検証", () => {
+    it("存在しないエージェントは404を返す", async () => {
+      mockPrisma.agentProfile.findUnique.mockResolvedValue(null);
+      const { GET } = await import("@/app/api/interview/[id]/evaluation/route");
+
+      const res = await GET(createGetRequest(), routeContext);
+      expect(res.status).toBe(404);
+    });
+
+    it("非公開エージェントは403を返す", async () => {
+      mockPrisma.agentProfile.findUnique.mockResolvedValue({
+        ...mockAgent,
+        status: "PRIVATE",
+      });
+      const { GET } = await import("@/app/api/interview/[id]/evaluation/route");
+
+      const res = await GET(createGetRequest(), routeContext);
+      expect(res.status).toBe(403);
+    });
+
+    it("アクセス拒否された企業は403を返す", async () => {
+      mockIsCompanyAccessDenied.mockResolvedValue(true);
+      const { GET } = await import("@/app/api/interview/[id]/evaluation/route");
+
+      const res = await GET(createGetRequest(), routeContext);
+      expect(res.status).toBe(403);
+      expect(mockIsCompanyAccessDenied).toHaveBeenCalledWith(
+        COMPANY_ID,
+        USER_ID,
+      );
+    });
+  });
+
+  describe("正常系", () => {
+    it("面接セッションがない場合はnullを返す", async () => {
+      mockPrisma.session.findFirst.mockResolvedValue(null);
+      const { GET } = await import("@/app/api/interview/[id]/evaluation/route");
+
+      const res = await GET(createGetRequest(), routeContext);
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.evaluation).toBeNull();
+    });
+
+    it("評価が存在する場合はそれを返す", async () => {
+      const { GET } = await import("@/app/api/interview/[id]/evaluation/route");
+
+      const res = await GET(createGetRequest(), routeContext);
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.evaluation).toEqual(mockEvaluation);
+    });
+
+    it("正しいセッション条件でクエリする", async () => {
+      const { GET } = await import("@/app/api/interview/[id]/evaluation/route");
+
+      await GET(createGetRequest(), routeContext);
+
+      expect(mockPrisma.session.findFirst).toHaveBeenCalledWith({
+        where: {
+          agentId: AGENT_ID,
+          recruiterId: RECRUITER_ID,
+          sessionType: "RECRUITER_AGENT_CHAT",
+        },
+      });
+    });
+  });
+});
+
+describe("POST /api/interview/[id]/evaluation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(recruiterSession);
+    mockIsCompanyAccessDenied.mockResolvedValue(false);
+    mockPrisma.agentProfile.findUnique.mockResolvedValue(mockAgent);
+    mockPrisma.session.findFirst.mockResolvedValue(mockChatSession);
+    mockPrisma.interviewEvaluation.upsert.mockResolvedValue(mockEvaluation);
+  });
+
+  describe("バリデーション", () => {
+    it("評価項目がない場合は400を返す", async () => {
+      const { POST } = await import(
+        "@/app/api/interview/[id]/evaluation/route"
+      );
+
+      const res = await POST(createPostRequest({}), routeContext);
+      expect(res.status).toBe(400);
+    });
+
+    it("評価が範囲外（0以下）の場合は400を返す", async () => {
+      const { POST } = await import(
+        "@/app/api/interview/[id]/evaluation/route"
+      );
+
+      const res = await POST(
+        createPostRequest({ ...validEvaluationBody, overallRating: 0 }),
+        routeContext,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("評価が範囲外（6以上）の場合は400を返す", async () => {
+      const { POST } = await import(
+        "@/app/api/interview/[id]/evaluation/route"
+      );
+
+      const res = await POST(
+        createPostRequest({ ...validEvaluationBody, technicalRating: 6 }),
+        routeContext,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("評価が小数の場合は400を返す", async () => {
+      const { POST } = await import(
+        "@/app/api/interview/[id]/evaluation/route"
+      );
+
+      const res = await POST(
+        createPostRequest({
+          ...validEvaluationBody,
+          communicationRating: 3.5,
+        }),
+        routeContext,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("コメントが5000文字を超える場合は400を返す", async () => {
+      const { POST } = await import(
+        "@/app/api/interview/[id]/evaluation/route"
+      );
+
+      const res = await POST(
+        createPostRequest({
+          ...validEvaluationBody,
+          comment: "a".repeat(5001),
+        }),
+        routeContext,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("コメントが5000文字以内の場合は受け付ける", async () => {
+      const { POST } = await import(
+        "@/app/api/interview/[id]/evaluation/route"
+      );
+
+      const res = await POST(
+        createPostRequest({
+          ...validEvaluationBody,
+          comment: "a".repeat(5000),
+        }),
+        routeContext,
+      );
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("エージェント検証", () => {
+    it("存在しないエージェントは404を返す", async () => {
+      mockPrisma.agentProfile.findUnique.mockResolvedValue(null);
+      const { POST } = await import(
+        "@/app/api/interview/[id]/evaluation/route"
+      );
+
+      const res = await POST(
+        createPostRequest(validEvaluationBody),
+        routeContext,
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it("面接セッションがない場合は404を返す", async () => {
+      mockPrisma.session.findFirst.mockResolvedValue(null);
+      const { POST } = await import(
+        "@/app/api/interview/[id]/evaluation/route"
+      );
+
+      const res = await POST(
+        createPostRequest(validEvaluationBody),
+        routeContext,
+      );
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("正常系", () => {
+    it("評価をupsertで作成・更新し200を返す", async () => {
+      const { POST } = await import(
+        "@/app/api/interview/[id]/evaluation/route"
+      );
+
+      const res = await POST(
+        createPostRequest(validEvaluationBody),
+        routeContext,
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.evaluation).toEqual(mockEvaluation);
+    });
+
+    it("upsertに正しいパラメータを渡す", async () => {
+      const { POST } = await import(
+        "@/app/api/interview/[id]/evaluation/route"
+      );
+
+      await POST(createPostRequest(validEvaluationBody), routeContext);
+
+      expect(mockPrisma.interviewEvaluation.upsert).toHaveBeenCalledWith({
+        where: { sessionId: SESSION_ID },
+        update: {
+          overallRating: 4,
+          technicalRating: 3,
+          communicationRating: 5,
+          cultureRating: 4,
+          comment: "優秀な候補者です。",
+        },
+        create: {
+          sessionId: SESSION_ID,
+          recruiterId: RECRUITER_ID,
+          overallRating: 4,
+          technicalRating: 3,
+          communicationRating: 5,
+          cultureRating: 4,
+          comment: "優秀な候補者です。",
+        },
+      });
+    });
+
+    it("コメントなしの場合はnullが保存される", async () => {
+      const { POST } = await import(
+        "@/app/api/interview/[id]/evaluation/route"
+      );
+
+      const { comment: _, ...bodyWithoutComment } = validEvaluationBody;
+      await POST(createPostRequest(bodyWithoutComment), routeContext);
+
+      expect(mockPrisma.interviewEvaluation.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          update: expect.objectContaining({ comment: null }),
+          create: expect.objectContaining({ comment: null }),
+        }),
+      );
+    });
+
+    it("空コメントの場合はnullが保存される", async () => {
+      const { POST } = await import(
+        "@/app/api/interview/[id]/evaluation/route"
+      );
+
+      await POST(
+        createPostRequest({ ...validEvaluationBody, comment: "" }),
+        routeContext,
+      );
+
+      expect(mockPrisma.interviewEvaluation.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          update: expect.objectContaining({ comment: null }),
+          create: expect.objectContaining({ comment: null }),
+        }),
+      );
+    });
+  });
+});

--- a/src/app/api/interview/[id]/evaluation/route.ts
+++ b/src/app/api/interview/[id]/evaluation/route.ts
@@ -54,7 +54,7 @@ const evaluationSchema = z.object({
   technicalRating: z.number().int().min(1).max(5),
   communicationRating: z.number().int().min(1).max(5),
   cultureRating: z.number().int().min(1).max(5),
-  comment: z.string().optional(),
+  comment: z.string().max(5000).optional(),
 });
 
 export const POST = withRecruiterAuth<RouteContext>(

--- a/src/app/api/interview/[id]/notes/route.ts
+++ b/src/app/api/interview/[id]/notes/route.ts
@@ -54,7 +54,7 @@ export const GET = withRecruiterAuth<RouteContext>(
 );
 
 const noteSchema = z.object({
-  content: z.string().min(1, "メモの内容を入力してください"),
+  content: z.string().min(1, "メモの内容を入力してください").max(5000),
 });
 
 export const POST = withRecruiterAuth<RouteContext>(

--- a/src/app/api/invites/[token]/__tests__/invite.test.ts
+++ b/src/app/api/invites/[token]/__tests__/invite.test.ts
@@ -1,0 +1,332 @@
+import { Prisma } from "@prisma/client";
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// bcryptjs モック
+const mockHash = vi.fn();
+vi.mock("bcryptjs", () => ({
+  hash: (...args: unknown[]) => mockHash(...args),
+}));
+
+// Logger モック
+const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+vi.mock("@/lib/logger", () => ({ logger: mockLogger }));
+
+// NextAuth モック（withErrorHandling用）
+vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+
+// Prisma トランザクション用クライアント
+const mockTxClient = {
+  account: { create: vi.fn() },
+  invite: { updateMany: vi.fn() },
+};
+
+// Prisma メインクライアント
+const mockPrisma = {
+  invite: { findUnique: vi.fn(), update: vi.fn() },
+  account: { findUnique: vi.fn() },
+  $transaction: vi.fn(),
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+const INVITE_TOKEN = "valid-invite-token-abc123";
+const COMPANY_ID = "company-001";
+const ACCOUNT_ID = "new-account-001";
+
+const mockCompany = {
+  id: COMPANY_ID,
+  name: "テスト株式会社",
+  slug: "test-company",
+};
+
+const validInvite = {
+  id: "invite-001",
+  token: INVITE_TOKEN,
+  email: "newuser@example.com",
+  role: "MEMBER",
+  status: "PENDING",
+  companyId: COMPANY_ID,
+  company: mockCompany,
+  invitedByAccountId: "inviter-001",
+  expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7日後
+  createdAt: new Date(),
+};
+
+function createGetRequest(): NextRequest {
+  return new NextRequest(`http://localhost/api/invites/${INVITE_TOKEN}`, {
+    method: "GET",
+  });
+}
+
+function createPostRequest(body: unknown): NextRequest {
+  return new NextRequest(`http://localhost/api/invites/${INVITE_TOKEN}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const routeContext = { params: Promise.resolve({ token: INVITE_TOKEN }) };
+
+describe("GET /api/invites/[token]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma.invite.findUnique.mockResolvedValue(validInvite);
+  });
+
+  it("有効な招待の情報を返す", async () => {
+    const { GET } = await import("@/app/api/invites/[token]/route");
+
+    const res = await GET(createGetRequest(), routeContext);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.email).toBe("newuser@example.com");
+    expect(data.companyName).toBe("テスト株式会社");
+    expect(data.role).toBe("MEMBER");
+  });
+
+  it("存在しない招待は404を返す", async () => {
+    mockPrisma.invite.findUnique.mockResolvedValue(null);
+    const { GET } = await import("@/app/api/invites/[token]/route");
+
+    const res = await GET(createGetRequest(), routeContext);
+    expect(res.status).toBe(404);
+  });
+
+  it("使用済みの招待は410を返す", async () => {
+    mockPrisma.invite.findUnique.mockResolvedValue({
+      ...validInvite,
+      status: "USED",
+    });
+    const { GET } = await import("@/app/api/invites/[token]/route");
+
+    const res = await GET(createGetRequest(), routeContext);
+    expect(res.status).toBe(410);
+  });
+
+  it("期限切れの招待は410を返しステータスを更新する", async () => {
+    mockPrisma.invite.findUnique.mockResolvedValue({
+      ...validInvite,
+      expiresAt: new Date(Date.now() - 1000), // 過去
+    });
+    mockPrisma.invite.update.mockResolvedValue({});
+    const { GET } = await import("@/app/api/invites/[token]/route");
+
+    const res = await GET(createGetRequest(), routeContext);
+    expect(res.status).toBe(410);
+    expect(mockPrisma.invite.update).toHaveBeenCalledWith({
+      where: { id: "invite-001" },
+      data: { status: "EXPIRED" },
+    });
+  });
+});
+
+describe("POST /api/invites/[token]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma.invite.findUnique.mockResolvedValue(validInvite);
+    mockHash.mockResolvedValue("hashed-password");
+    mockTxClient.account.create.mockResolvedValue({ id: ACCOUNT_ID });
+    mockTxClient.invite.updateMany.mockResolvedValue({ count: 1 });
+    mockPrisma.$transaction.mockImplementation(
+      async (callback: (tx: typeof mockTxClient) => Promise<unknown>) => {
+        return callback(mockTxClient);
+      },
+    );
+  });
+
+  describe("バリデーション", () => {
+    it("パスワードなしの場合は400を返す", async () => {
+      const { POST } = await import("@/app/api/invites/[token]/route");
+
+      const res = await POST(createPostRequest({}), routeContext);
+      expect(res.status).toBe(400);
+    });
+
+    it("パスワードが短すぎる場合は400を返す", async () => {
+      const { POST } = await import("@/app/api/invites/[token]/route");
+
+      const res = await POST(
+        createPostRequest({ password: "abc" }),
+        routeContext,
+      );
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("招待の検証", () => {
+    it("存在しない招待は404を返す", async () => {
+      mockPrisma.invite.findUnique.mockResolvedValue(null);
+      const { POST } = await import("@/app/api/invites/[token]/route");
+
+      const res = await POST(
+        createPostRequest({ password: "securePassword123" }),
+        routeContext,
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it("使用済みの招待は400を返す", async () => {
+      mockPrisma.invite.findUnique.mockResolvedValue({
+        ...validInvite,
+        status: "USED",
+      });
+      const { POST } = await import("@/app/api/invites/[token]/route");
+
+      const res = await POST(
+        createPostRequest({ password: "securePassword123" }),
+        routeContext,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("期限切れの招待は400を返しステータスをEXPIREDに更新する", async () => {
+      mockPrisma.invite.findUnique.mockResolvedValue({
+        ...validInvite,
+        expiresAt: new Date(Date.now() - 1000),
+      });
+      mockPrisma.invite.update.mockResolvedValue({});
+      const { POST } = await import("@/app/api/invites/[token]/route");
+
+      const res = await POST(
+        createPostRequest({ password: "securePassword123" }),
+        routeContext,
+      );
+      expect(res.status).toBe(400);
+      expect(mockPrisma.invite.update).toHaveBeenCalledWith({
+        where: { id: "invite-001" },
+        data: { status: "EXPIRED" },
+      });
+    });
+  });
+
+  describe("正常系", () => {
+    it("アカウントを作成し201を返す", async () => {
+      const { POST } = await import("@/app/api/invites/[token]/route");
+
+      const res = await POST(
+        createPostRequest({ password: "securePassword123" }),
+        routeContext,
+      );
+      expect(res.status).toBe(201);
+      const data = await res.json();
+      expect(data.accountId).toBe(ACCOUNT_ID);
+    });
+
+    it("トランザクション内でアカウント作成と招待更新を行う", async () => {
+      const { POST } = await import("@/app/api/invites/[token]/route");
+
+      await POST(
+        createPostRequest({ password: "securePassword123" }),
+        routeContext,
+      );
+
+      expect(mockTxClient.account.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          email: "newuser@example.com",
+          passwordHash: "hashed-password",
+          accountType: "RECRUITER",
+          emailVerified: true,
+          recruiter: {
+            create: expect.objectContaining({
+              companyId: COMPANY_ID,
+              role: "MEMBER",
+              status: "ACTIVE",
+              invitedByAccountId: "inviter-001",
+            }),
+          },
+        }),
+      });
+
+      expect(mockTxClient.invite.updateMany).toHaveBeenCalledWith({
+        where: { id: "invite-001", status: "PENDING" },
+        data: expect.objectContaining({
+          status: "USED",
+          usedAccountId: ACCOUNT_ID,
+        }),
+      });
+    });
+
+    it("パスワードをbcryptでハッシュ化する", async () => {
+      const { POST } = await import("@/app/api/invites/[token]/route");
+
+      await POST(
+        createPostRequest({ password: "securePassword123" }),
+        routeContext,
+      );
+
+      expect(mockHash).toHaveBeenCalledWith("securePassword123", 12);
+    });
+  });
+
+  describe("招待ステータス競合（TOCTOU対策）", () => {
+    it("同時リクエストで招待が既に使用済みなら409を返す", async () => {
+      mockTxClient.invite.updateMany.mockResolvedValue({ count: 0 });
+      const { POST } = await import("@/app/api/invites/[token]/route");
+
+      const res = await POST(
+        createPostRequest({ password: "securePassword123" }),
+        routeContext,
+      );
+      expect(res.status).toBe(409);
+    });
+  });
+
+  describe("メールアドレス競合（TOCTOU対策）", () => {
+    it("P2002ユニーク制約違反時は409を返す", async () => {
+      const p2002Error = new Prisma.PrismaClientKnownRequestError(
+        "Unique constraint failed",
+        { code: "P2002", clientVersion: "6.0.0", meta: { target: ["email"] } },
+      );
+      mockPrisma.$transaction.mockRejectedValue(p2002Error);
+      const { POST } = await import("@/app/api/invites/[token]/route");
+
+      const res = await POST(
+        createPostRequest({ password: "securePassword123" }),
+        routeContext,
+      );
+      expect(res.status).toBe(409);
+      const data = await res.json();
+      expect(data.error).toContain("既に使用されています");
+    });
+
+    it("P2002エラー時にログ出力する", async () => {
+      const p2002Error = new Prisma.PrismaClientKnownRequestError(
+        "Unique constraint failed",
+        { code: "P2002", clientVersion: "6.0.0", meta: { target: ["email"] } },
+      );
+      mockPrisma.$transaction.mockRejectedValue(p2002Error);
+      const { POST } = await import("@/app/api/invites/[token]/route");
+
+      await POST(
+        createPostRequest({ password: "securePassword123" }),
+        routeContext,
+      );
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        "Invite acceptance email conflict",
+        expect.objectContaining({
+          email: "newuser@example.com",
+          inviteId: "invite-001",
+        }),
+      );
+    });
+
+    it("P2002以外のPrismaエラーはそのまま再スローされる", async () => {
+      const otherError = new Prisma.PrismaClientKnownRequestError(
+        "Foreign key constraint failed",
+        { code: "P2003", clientVersion: "6.0.0", meta: {} },
+      );
+      mockPrisma.$transaction.mockRejectedValue(otherError);
+      const { POST } = await import("@/app/api/invites/[token]/route");
+
+      const res = await POST(
+        createPostRequest({ password: "securePassword123" }),
+        routeContext,
+      );
+      // withErrorHandling が500を返す
+      expect(res.status).toBe(500);
+    });
+  });
+});

--- a/src/app/api/recruiter/invites/[id]/__tests__/invite-manage.test.ts
+++ b/src/app/api/recruiter/invites/[id]/__tests__/invite-manage.test.ts
@@ -1,0 +1,272 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mocks ──────────────────────────────────────────────────────────
+
+const mockGetServerSession = vi.fn();
+vi.mock("next-auth", () => ({
+  getServerSession: () => mockGetServerSession(),
+}));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+
+const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+vi.mock("@/lib/logger", () => ({ logger: mockLogger }));
+
+const mockPrisma = {
+  invite: {
+    findFirst: vi.fn(),
+    updateMany: vi.fn(),
+  },
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+const mockGetRecruiterWithCompany = vi.fn();
+const mockCanManageMembers = vi.fn();
+vi.mock("@/lib/company", () => ({
+  getRecruiterWithCompany: (...args: unknown[]) =>
+    mockGetRecruiterWithCompany(...args),
+  canManageMembers: (...args: unknown[]) => mockCanManageMembers(...args),
+}));
+
+// ── Constants ──────────────────────────────────────────────────────
+
+const RECRUITER_ID = "recruiter-001";
+const COMPANY_ID = "company-001";
+const ACCOUNT_ID = "acc-1";
+const INVITE_ID = "invite-001";
+
+const ownerSession = {
+  user: {
+    accountId: ACCOUNT_ID,
+    recruiterId: RECRUITER_ID,
+    companyId: COMPANY_ID,
+    accountType: "RECRUITER",
+    recruiterStatus: "ACTIVE",
+  },
+};
+
+const mockCompanyData = {
+  company: { id: COMPANY_ID, name: "テスト企業" },
+  recruiter: { id: RECRUITER_ID, role: "OWNER", companyId: COMPANY_ID },
+};
+
+const mockInvite = {
+  id: INVITE_ID,
+  email: "invited@example.com",
+  role: "MEMBER",
+  status: "PENDING",
+  companyId: COMPANY_ID,
+  token: "abc123",
+  expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+  invitedByAccountId: ACCOUNT_ID,
+};
+
+const routeContext = {
+  params: Promise.resolve({ id: INVITE_ID }),
+};
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function createPatchRequest(body: unknown): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/recruiter/invites/${INVITE_ID}`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+// ── PATCH Tests ────────────────────────────────────────────────────
+
+describe("PATCH /api/recruiter/invites/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(ownerSession);
+    mockGetRecruiterWithCompany.mockResolvedValue(mockCompanyData);
+    mockCanManageMembers.mockReturnValue(true);
+    mockPrisma.invite.findFirst.mockResolvedValue(mockInvite);
+    mockPrisma.invite.updateMany.mockResolvedValue({ count: 1 });
+  });
+
+  it("招待をREVOKEDに更新できる", async () => {
+    const { PATCH } = await import("@/app/api/recruiter/invites/[id]/route");
+    const response = await PATCH(
+      createPatchRequest({ status: "REVOKED" }),
+      routeContext,
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.id).toBe(INVITE_ID);
+    expect(data.status).toBe("REVOKED");
+  });
+
+  it("同じcompanyIdの招待のみ取得する", async () => {
+    const { PATCH } = await import("@/app/api/recruiter/invites/[id]/route");
+    await PATCH(createPatchRequest({ status: "REVOKED" }), routeContext);
+
+    expect(mockPrisma.invite.findFirst).toHaveBeenCalledWith({
+      where: { id: INVITE_ID, companyId: COMPANY_ID },
+    });
+  });
+
+  it("条件付きupdateManyで更新する（TOCTOU防止）", async () => {
+    const { PATCH } = await import("@/app/api/recruiter/invites/[id]/route");
+    await PATCH(createPatchRequest({ status: "REVOKED" }), routeContext);
+
+    expect(mockPrisma.invite.updateMany).toHaveBeenCalledWith({
+      where: { id: INVITE_ID, status: "PENDING" },
+      data: { status: "REVOKED" },
+    });
+  });
+
+  it("同時リクエストでステータス変更済みなら409を返す", async () => {
+    mockPrisma.invite.updateMany.mockResolvedValue({ count: 0 });
+
+    const { PATCH } = await import("@/app/api/recruiter/invites/[id]/route");
+    const response = await PATCH(
+      createPatchRequest({ status: "REVOKED" }),
+      routeContext,
+    );
+
+    expect(response.status).toBe(409);
+  });
+
+  it("PENDING以外のステータスの招待は409を返す", async () => {
+    mockPrisma.invite.findFirst.mockResolvedValue({
+      ...mockInvite,
+      status: "USED",
+    });
+
+    const { PATCH } = await import("@/app/api/recruiter/invites/[id]/route");
+    const response = await PATCH(
+      createPatchRequest({ status: "REVOKED" }),
+      routeContext,
+    );
+
+    expect(response.status).toBe(409);
+    expect(mockPrisma.invite.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("REVOKED済みの招待は409を返す", async () => {
+    mockPrisma.invite.findFirst.mockResolvedValue({
+      ...mockInvite,
+      status: "REVOKED",
+    });
+
+    const { PATCH } = await import("@/app/api/recruiter/invites/[id]/route");
+    const response = await PATCH(
+      createPatchRequest({ status: "REVOKED" }),
+      routeContext,
+    );
+
+    expect(response.status).toBe(409);
+    expect(mockPrisma.invite.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("未認証の場合401を返す", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const { PATCH } = await import("@/app/api/recruiter/invites/[id]/route");
+    const response = await PATCH(
+      createPatchRequest({ status: "REVOKED" }),
+      routeContext,
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("recruiterIdがない場合403を返す", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: {
+        accountId: ACCOUNT_ID,
+        accountType: "RECRUITER",
+        recruiterStatus: "ACTIVE",
+      },
+    });
+
+    const { PATCH } = await import("@/app/api/recruiter/invites/[id]/route");
+    const response = await PATCH(
+      createPatchRequest({ status: "REVOKED" }),
+      routeContext,
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("権限がない場合403を返す", async () => {
+    mockCanManageMembers.mockReturnValue(false);
+
+    const { PATCH } = await import("@/app/api/recruiter/invites/[id]/route");
+    const response = await PATCH(
+      createPatchRequest({ status: "REVOKED" }),
+      routeContext,
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("招待が見つからない場合404を返す", async () => {
+    mockPrisma.invite.findFirst.mockResolvedValue(null);
+
+    const { PATCH } = await import("@/app/api/recruiter/invites/[id]/route");
+    const response = await PATCH(
+      createPatchRequest({ status: "REVOKED" }),
+      routeContext,
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it("無効なステータスで400を返す", async () => {
+    const { PATCH } = await import("@/app/api/recruiter/invites/[id]/route");
+    const response = await PATCH(
+      createPatchRequest({ status: "ACTIVE" }),
+      routeContext,
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("ステータスなしで400を返す", async () => {
+    const { PATCH } = await import("@/app/api/recruiter/invites/[id]/route");
+    const response = await PATCH(createPatchRequest({}), routeContext);
+
+    expect(response.status).toBe(400);
+  });
+
+  it("他の会社の招待はfindFirstで見つからず404を返す", async () => {
+    const otherCompanySession = {
+      user: {
+        accountId: "acc-2",
+        recruiterId: "recruiter-999",
+        companyId: "company-999",
+        accountType: "RECRUITER",
+        recruiterStatus: "ACTIVE",
+      },
+    };
+    mockGetServerSession.mockResolvedValue(otherCompanySession);
+    mockGetRecruiterWithCompany.mockResolvedValue({
+      company: { id: "company-999", name: "他社" },
+      recruiter: {
+        id: "recruiter-999",
+        role: "OWNER",
+        companyId: "company-999",
+      },
+    });
+    mockPrisma.invite.findFirst.mockResolvedValue(null);
+
+    const { PATCH } = await import("@/app/api/recruiter/invites/[id]/route");
+    const response = await PATCH(
+      createPatchRequest({ status: "REVOKED" }),
+      routeContext,
+    );
+
+    expect(response.status).toBe(404);
+    expect(mockPrisma.invite.findFirst).toHaveBeenCalledWith({
+      where: { id: INVITE_ID, companyId: "company-999" },
+    });
+  });
+});

--- a/src/app/api/recruiter/invites/__tests__/invites.test.ts
+++ b/src/app/api/recruiter/invites/__tests__/invites.test.ts
@@ -1,0 +1,316 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mocks ──────────────────────────────────────────────────────────
+
+const mockGetServerSession = vi.fn();
+vi.mock("next-auth", () => ({
+  getServerSession: () => mockGetServerSession(),
+}));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+
+const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+vi.mock("@/lib/logger", () => ({ logger: mockLogger }));
+
+const mockPrisma = {
+  recruiter: { findFirst: vi.fn() },
+  invite: { create: vi.fn() },
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+const mockGetRecruiterWithCompany = vi.fn();
+const mockCanManageMembers = vi.fn();
+vi.mock("@/lib/company", () => ({
+  getRecruiterWithCompany: (...args: unknown[]) =>
+    mockGetRecruiterWithCompany(...args),
+  canManageMembers: (...args: unknown[]) => mockCanManageMembers(...args),
+}));
+
+// ── Constants ──────────────────────────────────────────────────────
+
+const ACCOUNT_ID = "acc-001";
+const RECRUITER_ID = "recruiter-001";
+const COMPANY_ID = "company-001";
+
+const recruiterSession = {
+  user: {
+    accountId: ACCOUNT_ID,
+    recruiterId: RECRUITER_ID,
+    companyId: COMPANY_ID,
+    accountType: "RECRUITER",
+    recruiterStatus: "ACTIVE",
+  },
+};
+
+const mockCompany = {
+  id: COMPANY_ID,
+  name: "テスト株式会社",
+  slug: "test-corp",
+};
+
+const mockRecruiter = {
+  id: RECRUITER_ID,
+  accountId: ACCOUNT_ID,
+  companyId: COMPANY_ID,
+  role: "OWNER",
+  status: "ACTIVE",
+};
+
+const mockInvite = {
+  id: "invite-001",
+  token: "mock-token-abc123",
+  companyId: COMPANY_ID,
+  email: "newmember@example.com",
+  role: "MEMBER",
+  status: "PENDING",
+  expiresAt: new Date("2024-01-22"),
+  invitedByAccountId: ACCOUNT_ID,
+  createdAt: new Date("2024-01-15"),
+};
+
+const validBody = {
+  email: "newmember@example.com",
+  role: "MEMBER" as const,
+};
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function createPostRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/recruiter/invites", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// ── POST Tests ─────────────────────────────────────────────────────
+
+describe("POST /api/recruiter/invites", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(recruiterSession);
+    mockGetRecruiterWithCompany.mockResolvedValue({
+      company: mockCompany,
+      recruiter: mockRecruiter,
+    });
+    mockCanManageMembers.mockReturnValue(true);
+    mockPrisma.recruiter.findFirst.mockResolvedValue(null); // no existing member
+    mockPrisma.invite.create.mockResolvedValue(mockInvite);
+  });
+
+  it("招待を作成して201を返す", async () => {
+    const { POST } = await import("@/app/api/recruiter/invites/route");
+    const response = await POST(createPostRequest(validBody));
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.invite).toBeDefined();
+    expect(data.acceptUrl).toContain("/invite/");
+  });
+
+  it("正しいデータでinvite.createを呼ぶ", async () => {
+    const { POST } = await import("@/app/api/recruiter/invites/route");
+    await POST(createPostRequest(validBody));
+
+    expect(mockPrisma.invite.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        companyId: COMPANY_ID,
+        email: "newmember@example.com",
+        role: "MEMBER",
+        invitedByAccountId: ACCOUNT_ID,
+      }),
+    });
+  });
+
+  it("トークンと有効期限を含めて作成する", async () => {
+    const { POST } = await import("@/app/api/recruiter/invites/route");
+    await POST(createPostRequest(validBody));
+
+    const createCall = mockPrisma.invite.create.mock.calls[0][0];
+    expect(createCall.data.token).toBeDefined();
+    expect(typeof createCall.data.token).toBe("string");
+    expect(createCall.data.token.length).toBeGreaterThan(0);
+    expect(createCall.data.expiresAt).toBeInstanceOf(Date);
+    // 有効期限が7日後であることを確認
+    const now = Date.now();
+    const expiresMs = createCall.data.expiresAt.getTime();
+    const sevenDaysMs = 1000 * 60 * 60 * 24 * 7;
+    expect(expiresMs - now).toBeGreaterThan(sevenDaysMs - 5000); // 5秒の余裕
+    expect(expiresMs - now).toBeLessThan(sevenDaysMs + 5000);
+  });
+
+  it("acceptUrlにトークンを含む", async () => {
+    const { POST } = await import("@/app/api/recruiter/invites/route");
+    const response = await POST(createPostRequest(validBody));
+    const data = await response.json();
+
+    expect(data.acceptUrl).toMatch(/\/invite\/.+/);
+  });
+
+  it("ADMINロールの招待を作成できる", async () => {
+    const { POST } = await import("@/app/api/recruiter/invites/route");
+    const response = await POST(
+      createPostRequest({ email: "admin@example.com", role: "ADMIN" }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockPrisma.invite.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        role: "ADMIN",
+      }),
+    });
+  });
+
+  it("getRecruiterWithCompanyにrecruiterIdを渡す", async () => {
+    const { POST } = await import("@/app/api/recruiter/invites/route");
+    await POST(createPostRequest(validBody));
+
+    expect(mockGetRecruiterWithCompany).toHaveBeenCalledWith(RECRUITER_ID);
+  });
+
+  it("canManageMembersにロールを渡す", async () => {
+    const { POST } = await import("@/app/api/recruiter/invites/route");
+    await POST(createPostRequest(validBody));
+
+    expect(mockCanManageMembers).toHaveBeenCalledWith("OWNER");
+  });
+
+  // ── 重複チェック ──────────────────────────────────────────────────
+
+  it("既にメンバーの場合409を返す", async () => {
+    mockPrisma.recruiter.findFirst.mockResolvedValue({
+      id: "existing-recruiter",
+      companyId: COMPANY_ID,
+      status: "ACTIVE",
+    });
+
+    const { POST } = await import("@/app/api/recruiter/invites/route");
+    const response = await POST(createPostRequest(validBody));
+
+    expect(response.status).toBe(409);
+    expect(mockPrisma.invite.create).not.toHaveBeenCalled();
+  });
+
+  it("既存メンバーチェックで正しいクエリを使う", async () => {
+    const { POST } = await import("@/app/api/recruiter/invites/route");
+    await POST(createPostRequest(validBody));
+
+    expect(mockPrisma.recruiter.findFirst).toHaveBeenCalledWith({
+      where: {
+        companyId: COMPANY_ID,
+        account: { email: "newmember@example.com" },
+        status: "ACTIVE",
+      },
+    });
+  });
+
+  // ── 権限チェック ──────────────────────────────────────────────────
+
+  it("メンバー管理権限がない場合403を返す", async () => {
+    mockCanManageMembers.mockReturnValue(false);
+    mockGetRecruiterWithCompany.mockResolvedValue({
+      company: mockCompany,
+      recruiter: { ...mockRecruiter, role: "MEMBER" },
+    });
+
+    const { POST } = await import("@/app/api/recruiter/invites/route");
+    const response = await POST(createPostRequest(validBody));
+
+    expect(response.status).toBe(403);
+    expect(mockPrisma.invite.create).not.toHaveBeenCalled();
+  });
+
+  it("USERアカウントタイプの場合403を返す", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: {
+        accountId: ACCOUNT_ID,
+        accountType: "USER",
+        userId: "user-001",
+      },
+    });
+
+    const { POST } = await import("@/app/api/recruiter/invites/route");
+    const response = await POST(createPostRequest(validBody));
+
+    expect(response.status).toBe(403);
+    expect(mockPrisma.invite.create).not.toHaveBeenCalled();
+  });
+
+  it("recruiterIdがない場合403を返す", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: {
+        accountId: ACCOUNT_ID,
+        accountType: "RECRUITER",
+        // recruiterId missing
+      },
+    });
+
+    const { POST } = await import("@/app/api/recruiter/invites/route");
+    const response = await POST(createPostRequest(validBody));
+
+    expect(response.status).toBe(403);
+  });
+
+  it("accountIdがない場合403を返す", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: {
+        accountType: "RECRUITER",
+        recruiterId: RECRUITER_ID,
+        // accountId missing
+      },
+    });
+
+    const { POST } = await import("@/app/api/recruiter/invites/route");
+    const response = await POST(createPostRequest(validBody));
+
+    expect(response.status).toBe(403);
+  });
+
+  // ── バリデーション ────────────────────────────────────────────────
+
+  it("メールアドレスなしで400を返す", async () => {
+    const { POST } = await import("@/app/api/recruiter/invites/route");
+    const response = await POST(createPostRequest({ role: "MEMBER" }));
+
+    expect(response.status).toBe(400);
+    expect(mockPrisma.invite.create).not.toHaveBeenCalled();
+  });
+
+  it("無効なメールアドレスで400を返す", async () => {
+    const { POST } = await import("@/app/api/recruiter/invites/route");
+    const response = await POST(
+      createPostRequest({ email: "invalid-email", role: "MEMBER" }),
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("ロールなしで400を返す", async () => {
+    const { POST } = await import("@/app/api/recruiter/invites/route");
+    const response = await POST(
+      createPostRequest({ email: "test@example.com" }),
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("無効なロールで400を返す", async () => {
+    const { POST } = await import("@/app/api/recruiter/invites/route");
+    const response = await POST(
+      createPostRequest({ email: "test@example.com", role: "OWNER" }),
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  // ── 認証 ──────────────────────────────────────────────────────────
+
+  it("未認証の場合401を返す", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const { POST } = await import("@/app/api/recruiter/invites/route");
+    const response = await POST(createPostRequest(validBody));
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/src/app/api/recruiter/jobs/[id]/__tests__/job-detail.test.ts
+++ b/src/app/api/recruiter/jobs/[id]/__tests__/job-detail.test.ts
@@ -1,0 +1,426 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mocks ──────────────────────────────────────────────────────────
+
+const mockGetServerSession = vi.fn();
+vi.mock("next-auth", () => ({
+  getServerSession: () => mockGetServerSession(),
+}));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+
+const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+vi.mock("@/lib/logger", () => ({ logger: mockLogger }));
+
+const mockPrisma = {
+  jobPosting: {
+    findFirst: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+// ── Constants ──────────────────────────────────────────────────────
+
+const RECRUITER_ID = "recruiter-001";
+const OTHER_RECRUITER_ID = "recruiter-999";
+const COMPANY_ID = "company-001";
+const JOB_ID = "job-001";
+
+const recruiterSession = {
+  user: {
+    accountId: "acc-1",
+    recruiterId: RECRUITER_ID,
+    companyId: COMPANY_ID,
+    accountType: "RECRUITER",
+    recruiterStatus: "ACTIVE",
+  },
+};
+
+const otherRecruiterSession = {
+  user: {
+    accountId: "acc-2",
+    recruiterId: OTHER_RECRUITER_ID,
+    companyId: COMPANY_ID,
+    accountType: "RECRUITER",
+    recruiterStatus: "ACTIVE",
+  },
+};
+
+const mockJob = {
+  id: JOB_ID,
+  recruiterId: RECRUITER_ID,
+  title: "フロントエンドエンジニア",
+  description: "Reactを用いたフロントエンド開発",
+  requirements: "React 3年以上",
+  preferredSkills: "TypeScript",
+  skills: ["React", "TypeScript"],
+  keywords: ["フロントエンド"],
+  employmentType: "FULL_TIME",
+  experienceLevel: "MID",
+  location: "東京",
+  salaryMin: 5000000,
+  salaryMax: 8000000,
+  isRemote: true,
+  status: "ACTIVE",
+  matches: [],
+  pipelines: [],
+  _count: { matches: 5, pipelines: 2, watches: 1 },
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const routeContext = {
+  params: Promise.resolve({ id: JOB_ID }),
+};
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function createRequest(method: string, body?: unknown): NextRequest {
+  if (body) {
+    return new NextRequest(`http://localhost/api/recruiter/jobs/${JOB_ID}`, {
+      method,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+  return new NextRequest(`http://localhost/api/recruiter/jobs/${JOB_ID}`, {
+    method,
+  });
+}
+
+// ── GET Tests ──────────────────────────────────────────────────────
+
+describe("GET /api/recruiter/jobs/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(recruiterSession);
+  });
+
+  it("自分の求人詳細を取得できる", async () => {
+    mockPrisma.jobPosting.findFirst.mockResolvedValue(mockJob);
+
+    const { GET } = await import("@/app/api/recruiter/jobs/[id]/route");
+    const response = await GET(createRequest("GET"), routeContext);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.job.id).toBe(JOB_ID);
+    expect(data.job.title).toBe("フロントエンドエンジニア");
+  });
+
+  it("recruiterId条件でフィルタされる（他リクルーターの求人は見えない）", async () => {
+    mockPrisma.jobPosting.findFirst.mockResolvedValue(mockJob);
+
+    const { GET } = await import("@/app/api/recruiter/jobs/[id]/route");
+    await GET(createRequest("GET"), routeContext);
+
+    expect(mockPrisma.jobPosting.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: JOB_ID,
+          recruiterId: RECRUITER_ID,
+        },
+      }),
+    );
+  });
+
+  it("存在しない求人の場合404を返す", async () => {
+    mockPrisma.jobPosting.findFirst.mockResolvedValue(null);
+
+    const { GET } = await import("@/app/api/recruiter/jobs/[id]/route");
+    const response = await GET(createRequest("GET"), routeContext);
+
+    expect(response.status).toBe(404);
+  });
+
+  it("未認証の場合401を返す", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const { GET } = await import("@/app/api/recruiter/jobs/[id]/route");
+    const response = await GET(createRequest("GET"), routeContext);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("recruiterIdがないユーザーは403を返す", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { accountId: "acc-1", accountType: "USER" },
+    });
+
+    const { GET } = await import("@/app/api/recruiter/jobs/[id]/route");
+    const response = await GET(createRequest("GET"), routeContext);
+
+    expect(response.status).toBe(403);
+  });
+
+  it("他のリクルーターの求人にはアクセスできない（findFirstがnull）", async () => {
+    mockGetServerSession.mockResolvedValue(otherRecruiterSession);
+    mockPrisma.jobPosting.findFirst.mockResolvedValue(null);
+
+    const { GET } = await import("@/app/api/recruiter/jobs/[id]/route");
+    const response = await GET(createRequest("GET"), routeContext);
+
+    expect(response.status).toBe(404);
+    // where条件にOTHER_RECRUITER_IDが使われることを確認
+    expect(mockPrisma.jobPosting.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: JOB_ID,
+          recruiterId: OTHER_RECRUITER_ID,
+        },
+      }),
+    );
+  });
+});
+
+// ── PATCH Tests ────────────────────────────────────────────────────
+
+describe("PATCH /api/recruiter/jobs/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(recruiterSession);
+    mockPrisma.jobPosting.findFirst.mockResolvedValue(mockJob);
+    mockPrisma.jobPosting.update.mockResolvedValue({
+      ...mockJob,
+      title: "更新されたタイトル",
+    });
+  });
+
+  it("求人を更新できる", async () => {
+    const { PATCH } = await import("@/app/api/recruiter/jobs/[id]/route");
+    const response = await PATCH(
+      createRequest("PATCH", { title: "更新されたタイトル" }),
+      routeContext,
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.job.title).toBe("更新されたタイトル");
+  });
+
+  it("更新時にrecruiterId条件で所有権を確認する", async () => {
+    const { PATCH } = await import("@/app/api/recruiter/jobs/[id]/route");
+    await PATCH(createRequest("PATCH", { title: "テスト" }), routeContext);
+
+    expect(mockPrisma.jobPosting.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: JOB_ID,
+        recruiterId: RECRUITER_ID,
+      },
+    });
+  });
+
+  it("正しいデータでupdateが呼ばれる", async () => {
+    const updateData = {
+      title: "バックエンドエンジニア",
+      salaryMin: 6000000,
+      skills: ["Go", "PostgreSQL"],
+    };
+
+    const { PATCH } = await import("@/app/api/recruiter/jobs/[id]/route");
+    await PATCH(createRequest("PATCH", updateData), routeContext);
+
+    expect(mockPrisma.jobPosting.update).toHaveBeenCalledWith({
+      where: { id: JOB_ID },
+      data: updateData,
+    });
+  });
+
+  it("存在しない求人の更新は404を返す", async () => {
+    mockPrisma.jobPosting.findFirst.mockResolvedValue(null);
+
+    const { PATCH } = await import("@/app/api/recruiter/jobs/[id]/route");
+    const response = await PATCH(
+      createRequest("PATCH", { title: "テスト" }),
+      routeContext,
+    );
+
+    expect(response.status).toBe(404);
+    expect(mockPrisma.jobPosting.update).not.toHaveBeenCalled();
+  });
+
+  it("未認証の場合401を返す", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const { PATCH } = await import("@/app/api/recruiter/jobs/[id]/route");
+    const response = await PATCH(
+      createRequest("PATCH", { title: "テスト" }),
+      routeContext,
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  // バリデーションテスト
+  describe("バリデーション", () => {
+    it("タイトルが空文字の場合400を返す", async () => {
+      const { PATCH } = await import("@/app/api/recruiter/jobs/[id]/route");
+      const response = await PATCH(
+        createRequest("PATCH", { title: "" }),
+        routeContext,
+      );
+
+      expect(response.status).toBe(400);
+      expect(mockPrisma.jobPosting.update).not.toHaveBeenCalled();
+    });
+
+    it("タイトルが200文字超の場合400を返す", async () => {
+      const { PATCH } = await import("@/app/api/recruiter/jobs/[id]/route");
+      const response = await PATCH(
+        createRequest("PATCH", { title: "あ".repeat(201) }),
+        routeContext,
+      );
+
+      expect(response.status).toBe(400);
+    });
+
+    it("descriptionが10000文字超の場合400を返す", async () => {
+      const { PATCH } = await import("@/app/api/recruiter/jobs/[id]/route");
+      const response = await PATCH(
+        createRequest("PATCH", { description: "あ".repeat(10001) }),
+        routeContext,
+      );
+
+      expect(response.status).toBe(400);
+    });
+
+    it("無効なemploymentTypeの場合400を返す", async () => {
+      const { PATCH } = await import("@/app/api/recruiter/jobs/[id]/route");
+      const response = await PATCH(
+        createRequest("PATCH", { employmentType: "INVALID" }),
+        routeContext,
+      );
+
+      expect(response.status).toBe(400);
+    });
+
+    it("無効なstatusの場合400を返す", async () => {
+      const { PATCH } = await import("@/app/api/recruiter/jobs/[id]/route");
+      const response = await PATCH(
+        createRequest("PATCH", { status: "DELETED" }),
+        routeContext,
+      );
+
+      expect(response.status).toBe(400);
+    });
+
+    it("skillsが50件超の場合400を返す", async () => {
+      const { PATCH } = await import("@/app/api/recruiter/jobs/[id]/route");
+      const response = await PATCH(
+        createRequest("PATCH", {
+          skills: Array.from({ length: 51 }, (_, i) => `skill-${i}`),
+        }),
+        routeContext,
+      );
+
+      expect(response.status).toBe(400);
+    });
+
+    it("nullable項目にnullを設定できる", async () => {
+      mockPrisma.jobPosting.update.mockResolvedValue({
+        ...mockJob,
+        requirements: null,
+        salaryMin: null,
+      });
+
+      const { PATCH } = await import("@/app/api/recruiter/jobs/[id]/route");
+      const response = await PATCH(
+        createRequest("PATCH", {
+          requirements: null,
+          salaryMin: null,
+        }),
+        routeContext,
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockPrisma.jobPosting.update).toHaveBeenCalledWith({
+        where: { id: JOB_ID },
+        data: { requirements: null, salaryMin: null },
+      });
+    });
+
+    it("有効なstatusを設定できる", async () => {
+      mockPrisma.jobPosting.update.mockResolvedValue({
+        ...mockJob,
+        status: "PAUSED",
+      });
+
+      const { PATCH } = await import("@/app/api/recruiter/jobs/[id]/route");
+      const response = await PATCH(
+        createRequest("PATCH", { status: "PAUSED" }),
+        routeContext,
+      );
+
+      expect(response.status).toBe(200);
+    });
+  });
+});
+
+// ── DELETE Tests ────────────────────────────────────────────────────
+
+describe("DELETE /api/recruiter/jobs/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(recruiterSession);
+    mockPrisma.jobPosting.findFirst.mockResolvedValue(mockJob);
+    mockPrisma.jobPosting.delete.mockResolvedValue(mockJob);
+  });
+
+  it("自分の求人を削除できる", async () => {
+    const { DELETE } = await import("@/app/api/recruiter/jobs/[id]/route");
+    const response = await DELETE(createRequest("DELETE"), routeContext);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+  });
+
+  it("削除時にrecruiterId条件で所有権を確認する", async () => {
+    const { DELETE } = await import("@/app/api/recruiter/jobs/[id]/route");
+    await DELETE(createRequest("DELETE"), routeContext);
+
+    expect(mockPrisma.jobPosting.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: JOB_ID,
+        recruiterId: RECRUITER_ID,
+      },
+    });
+    expect(mockPrisma.jobPosting.delete).toHaveBeenCalledWith({
+      where: { id: JOB_ID },
+    });
+  });
+
+  it("存在しない求人の削除は404を返す", async () => {
+    mockPrisma.jobPosting.findFirst.mockResolvedValue(null);
+
+    const { DELETE } = await import("@/app/api/recruiter/jobs/[id]/route");
+    const response = await DELETE(createRequest("DELETE"), routeContext);
+
+    expect(response.status).toBe(404);
+    expect(mockPrisma.jobPosting.delete).not.toHaveBeenCalled();
+  });
+
+  it("未認証の場合401を返す", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const { DELETE } = await import("@/app/api/recruiter/jobs/[id]/route");
+    const response = await DELETE(createRequest("DELETE"), routeContext);
+
+    expect(response.status).toBe(401);
+    expect(mockPrisma.jobPosting.delete).not.toHaveBeenCalled();
+  });
+
+  it("recruiter権限がない場合403を返す", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { accountId: "acc-1", accountType: "USER" },
+    });
+
+    const { DELETE } = await import("@/app/api/recruiter/jobs/[id]/route");
+    const response = await DELETE(createRequest("DELETE"), routeContext);
+
+    expect(response.status).toBe(403);
+    expect(mockPrisma.jobPosting.delete).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/recruiter/jobs/[id]/match/route.ts
+++ b/src/app/api/recruiter/jobs/[id]/match/route.ts
@@ -232,7 +232,10 @@ export const GET = withRecruiterAuth<RouteContext>(
   async (req, session, context) => {
     const { id: jobId } = await context.params;
     const searchParams = req.nextUrl.searchParams;
-    const minScore = Number.parseFloat(searchParams.get("minScore") || "0");
+    const rawMinScore = Number.parseFloat(searchParams.get("minScore") || "0");
+    const minScore = Number.isNaN(rawMinScore)
+      ? 0
+      : Math.max(0, Math.min(1, rawMinScore));
 
     const job = await prisma.jobPosting.findFirst({
       where: {

--- a/src/app/api/recruiter/jobs/[id]/route.ts
+++ b/src/app/api/recruiter/jobs/[id]/route.ts
@@ -60,19 +60,19 @@ export const GET = withRecruiterAuth<RouteContext>(
 );
 
 const jobUpdateSchema = z.object({
-  title: z.string().min(1).optional(),
-  description: z.string().min(1).optional(),
-  requirements: z.string().optional().nullable(),
-  preferredSkills: z.string().optional().nullable(),
-  skills: z.array(z.string()).optional(),
-  keywords: z.array(z.string()).optional(),
+  title: z.string().min(1).max(200).optional(),
+  description: z.string().min(1).max(10000).optional(),
+  requirements: z.string().max(5000).optional().nullable(),
+  preferredSkills: z.string().max(5000).optional().nullable(),
+  skills: z.array(z.string().max(200)).max(50).optional(),
+  keywords: z.array(z.string().max(200)).max(50).optional(),
   employmentType: z
     .enum(["FULL_TIME", "PART_TIME", "CONTRACT", "INTERNSHIP", "FREELANCE"])
     .optional(),
   experienceLevel: z
     .enum(["ENTRY", "JUNIOR", "MID", "SENIOR", "LEAD"])
     .optional(),
-  location: z.string().optional().nullable(),
+  location: z.string().max(500).optional().nullable(),
   salaryMin: z.number().optional().nullable(),
   salaryMax: z.number().optional().nullable(),
   isRemote: z.boolean().optional(),

--- a/src/app/api/recruiter/jobs/__tests__/jobs.test.ts
+++ b/src/app/api/recruiter/jobs/__tests__/jobs.test.ts
@@ -1,0 +1,389 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mocks ──────────────────────────────────────────────────────────
+
+const mockGetServerSession = vi.fn();
+vi.mock("next-auth", () => ({
+  getServerSession: () => mockGetServerSession(),
+}));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+
+const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+vi.mock("@/lib/logger", () => ({ logger: mockLogger }));
+
+const mockPrisma = {
+  jobPosting: {
+    findMany: vi.fn(),
+    create: vi.fn(),
+  },
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+// ── Constants ──────────────────────────────────────────────────────
+
+const RECRUITER_ID = "recruiter-001";
+const COMPANY_ID = "company-001";
+const ACCOUNT_ID = "acc-1";
+
+const recruiterSession = {
+  user: {
+    accountId: ACCOUNT_ID,
+    recruiterId: RECRUITER_ID,
+    companyId: COMPANY_ID,
+    accountType: "RECRUITER",
+    recruiterStatus: "ACTIVE",
+  },
+};
+
+const mockJob = {
+  id: "job-001",
+  recruiterId: RECRUITER_ID,
+  title: "フロントエンドエンジニア",
+  description: "React/TypeScript開発",
+  requirements: "3年以上の経験",
+  preferredSkills: "Next.js",
+  skills: ["React", "TypeScript"],
+  keywords: ["フロントエンド"],
+  employmentType: "FULL_TIME",
+  experienceLevel: "MID",
+  location: "東京",
+  salaryMin: 5000000,
+  salaryMax: 8000000,
+  isRemote: true,
+  status: "DRAFT",
+  createdAt: new Date("2024-01-01"),
+  updatedAt: new Date("2024-01-01"),
+  _count: { matches: 3, pipelines: 2 },
+};
+
+const validJobBody = {
+  title: "フロントエンドエンジニア",
+  description: "React/TypeScript開発",
+  employmentType: "FULL_TIME" as const,
+  experienceLevel: "MID" as const,
+};
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function createGetRequest(queryString = ""): NextRequest {
+  return new NextRequest(`http://localhost/api/recruiter/jobs${queryString}`, {
+    method: "GET",
+  });
+}
+
+function createPostRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/recruiter/jobs", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// ── GET Tests ──────────────────────────────────────────────────────
+
+describe("GET /api/recruiter/jobs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(recruiterSession);
+  });
+
+  it("求人一覧を返す", async () => {
+    mockPrisma.jobPosting.findMany.mockResolvedValue([mockJob]);
+
+    const { GET } = await import("@/app/api/recruiter/jobs/route");
+    const response = await GET(createGetRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.jobs).toHaveLength(1);
+    expect(data.jobs[0].title).toBe("フロントエンドエンジニア");
+    expect(data.jobs[0]._count.matches).toBe(3);
+    expect(data.jobs[0]._count.pipelines).toBe(2);
+  });
+
+  it("自分のrecruiterIdでフィルタする", async () => {
+    mockPrisma.jobPosting.findMany.mockResolvedValue([]);
+
+    const { GET } = await import("@/app/api/recruiter/jobs/route");
+    await GET(createGetRequest());
+
+    expect(mockPrisma.jobPosting.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          recruiterId: RECRUITER_ID,
+        }),
+      }),
+    );
+  });
+
+  it("statusパラメータでフィルタできる", async () => {
+    mockPrisma.jobPosting.findMany.mockResolvedValue([]);
+
+    const { GET } = await import("@/app/api/recruiter/jobs/route");
+    await GET(createGetRequest("?status=ACTIVE"));
+
+    expect(mockPrisma.jobPosting.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          recruiterId: RECRUITER_ID,
+          status: "ACTIVE",
+        }),
+      }),
+    );
+  });
+
+  it("statusなしの場合はステータスフィルタなし", async () => {
+    mockPrisma.jobPosting.findMany.mockResolvedValue([]);
+
+    const { GET } = await import("@/app/api/recruiter/jobs/route");
+    await GET(createGetRequest());
+
+    const callArgs = mockPrisma.jobPosting.findMany.mock.calls[0][0];
+    expect(callArgs.where.status).toBeUndefined();
+  });
+
+  it("空の求人リストを返す", async () => {
+    mockPrisma.jobPosting.findMany.mockResolvedValue([]);
+
+    const { GET } = await import("@/app/api/recruiter/jobs/route");
+    const response = await GET(createGetRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.jobs).toEqual([]);
+  });
+
+  it("updatedAtの降順でソートする", async () => {
+    mockPrisma.jobPosting.findMany.mockResolvedValue([]);
+
+    const { GET } = await import("@/app/api/recruiter/jobs/route");
+    await GET(createGetRequest());
+
+    expect(mockPrisma.jobPosting.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: { updatedAt: "desc" },
+      }),
+    );
+  });
+
+  it("未認証の場合401を返す", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const { GET } = await import("@/app/api/recruiter/jobs/route");
+    const response = await GET(createGetRequest());
+
+    expect(response.status).toBe(401);
+  });
+
+  it("recruiterIdがない場合403を返す", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { accountId: ACCOUNT_ID, companyId: COMPANY_ID },
+    });
+
+    const { GET } = await import("@/app/api/recruiter/jobs/route");
+    const response = await GET(createGetRequest());
+
+    expect(response.status).toBe(403);
+  });
+});
+
+// ── POST Tests ─────────────────────────────────────────────────────
+
+describe("POST /api/recruiter/jobs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(recruiterSession);
+    mockPrisma.jobPosting.create.mockResolvedValue(mockJob);
+  });
+
+  it("求人を作成して201を返す", async () => {
+    const { POST } = await import("@/app/api/recruiter/jobs/route");
+    const response = await POST(createPostRequest(validJobBody));
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.job).toBeDefined();
+  });
+
+  it("recruiterIdを含めて作成する", async () => {
+    const { POST } = await import("@/app/api/recruiter/jobs/route");
+    await POST(createPostRequest(validJobBody));
+
+    expect(mockPrisma.jobPosting.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        recruiterId: RECRUITER_ID,
+        title: "フロントエンドエンジニア",
+        description: "React/TypeScript開発",
+        employmentType: "FULL_TIME",
+        experienceLevel: "MID",
+      }),
+    });
+  });
+
+  it("全フィールドを含むリクエストで作成できる", async () => {
+    const fullBody = {
+      ...validJobBody,
+      requirements: "3年以上の経験",
+      preferredSkills: "Next.js経験",
+      skills: ["React", "TypeScript"],
+      keywords: ["フロントエンド"],
+      location: "東京",
+      salaryMin: 5000000,
+      salaryMax: 8000000,
+      isRemote: true,
+      status: "ACTIVE",
+    };
+
+    const { POST } = await import("@/app/api/recruiter/jobs/route");
+    const response = await POST(createPostRequest(fullBody));
+
+    expect(response.status).toBe(201);
+    expect(mockPrisma.jobPosting.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        recruiterId: RECRUITER_ID,
+        requirements: "3年以上の経験",
+        skills: ["React", "TypeScript"],
+        isRemote: true,
+        status: "ACTIVE",
+      }),
+    });
+  });
+
+  it("デフォルト値が適用される（skills=[], keywords=[], isRemote=false, status=DRAFT）", async () => {
+    const { POST } = await import("@/app/api/recruiter/jobs/route");
+    await POST(createPostRequest(validJobBody));
+
+    expect(mockPrisma.jobPosting.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        skills: [],
+        keywords: [],
+        isRemote: false,
+        status: "DRAFT",
+      }),
+    });
+  });
+
+  it("タイトルなしで400を返す", async () => {
+    const { POST } = await import("@/app/api/recruiter/jobs/route");
+    const response = await POST(
+      createPostRequest({
+        description: "説明",
+        employmentType: "FULL_TIME",
+        experienceLevel: "MID",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockPrisma.jobPosting.create).not.toHaveBeenCalled();
+  });
+
+  it("説明なしで400を返す", async () => {
+    const { POST } = await import("@/app/api/recruiter/jobs/route");
+    const response = await POST(
+      createPostRequest({
+        title: "タイトル",
+        employmentType: "FULL_TIME",
+        experienceLevel: "MID",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("無効な雇用形態で400を返す", async () => {
+    const { POST } = await import("@/app/api/recruiter/jobs/route");
+    const response = await POST(
+      createPostRequest({
+        ...validJobBody,
+        employmentType: "INVALID",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("無効な経験レベルで400を返す", async () => {
+    const { POST } = await import("@/app/api/recruiter/jobs/route");
+    const response = await POST(
+      createPostRequest({
+        ...validJobBody,
+        experienceLevel: "INVALID",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("タイトルが200文字を超えると400を返す", async () => {
+    const { POST } = await import("@/app/api/recruiter/jobs/route");
+    const response = await POST(
+      createPostRequest({
+        ...validJobBody,
+        title: "a".repeat(201),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("未認証の場合401を返す", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const { POST } = await import("@/app/api/recruiter/jobs/route");
+    const response = await POST(createPostRequest(validJobBody));
+
+    expect(response.status).toBe(401);
+  });
+
+  it("recruiterIdがない場合403を返す", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { accountId: ACCOUNT_ID, companyId: COMPANY_ID },
+    });
+
+    const { POST } = await import("@/app/api/recruiter/jobs/route");
+    const response = await POST(createPostRequest(validJobBody));
+
+    expect(response.status).toBe(403);
+  });
+
+  it("全ての有効な雇用形態を受け入れる", async () => {
+    const types = [
+      "FULL_TIME",
+      "PART_TIME",
+      "CONTRACT",
+      "INTERNSHIP",
+      "FREELANCE",
+    ];
+
+    const { POST } = await import("@/app/api/recruiter/jobs/route");
+
+    for (const employmentType of types) {
+      vi.clearAllMocks();
+      mockGetServerSession.mockResolvedValue(recruiterSession);
+      mockPrisma.jobPosting.create.mockResolvedValue(mockJob);
+
+      const response = await POST(
+        createPostRequest({ ...validJobBody, employmentType }),
+      );
+      expect(response.status).toBe(201);
+    }
+  });
+
+  it("全ての有効な経験レベルを受け入れる", async () => {
+    const levels = ["ENTRY", "JUNIOR", "MID", "SENIOR", "LEAD"];
+
+    const { POST } = await import("@/app/api/recruiter/jobs/route");
+
+    for (const experienceLevel of levels) {
+      vi.clearAllMocks();
+      mockGetServerSession.mockResolvedValue(recruiterSession);
+      mockPrisma.jobPosting.create.mockResolvedValue(mockJob);
+
+      const response = await POST(
+        createPostRequest({ ...validJobBody, experienceLevel }),
+      );
+      expect(response.status).toBe(201);
+    }
+  });
+});

--- a/src/app/api/recruiter/jobs/route.ts
+++ b/src/app/api/recruiter/jobs/route.ts
@@ -29,12 +29,12 @@ export const GET = withRecruiterAuth(async (request, session) => {
 });
 
 const jobPostingSchema = z.object({
-  title: z.string().min(1, "タイトルは必須です"),
-  description: z.string().min(1, "説明は必須です"),
-  requirements: z.string().optional(),
-  preferredSkills: z.string().optional(),
-  skills: z.array(z.string()).default([]),
-  keywords: z.array(z.string()).default([]),
+  title: z.string().min(1, "タイトルは必須です").max(200),
+  description: z.string().min(1, "説明は必須です").max(10000),
+  requirements: z.string().max(5000).optional(),
+  preferredSkills: z.string().max(5000).optional(),
+  skills: z.array(z.string().max(200)).max(50).default([]),
+  keywords: z.array(z.string().max(200)).max(50).default([]),
   employmentType: z.enum(
     ["FULL_TIME", "PART_TIME", "CONTRACT", "INTERNSHIP", "FREELANCE"],
     {
@@ -46,7 +46,7 @@ const jobPostingSchema = z.object({
     message:
       "経験レベルはENTRY, JUNIOR, MID, SENIOR, LEADのいずれかを指定してください",
   }),
-  location: z.string().optional(),
+  location: z.string().max(500).optional(),
   salaryMin: z.number().optional(),
   salaryMax: z.number().optional(),
   isRemote: z.boolean().default(false),

--- a/src/app/api/recruiter/members/[id]/__tests__/member-manage.test.ts
+++ b/src/app/api/recruiter/members/[id]/__tests__/member-manage.test.ts
@@ -1,0 +1,360 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mocks ──────────────────────────────────────────────────────────
+
+const mockGetServerSession = vi.fn();
+vi.mock("next-auth", () => ({
+  getServerSession: () => mockGetServerSession(),
+}));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+
+const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+vi.mock("@/lib/logger", () => ({ logger: mockLogger }));
+
+const mockPrisma = {
+  recruiter: {
+    findFirst: vi.fn(),
+    updateMany: vi.fn(),
+  },
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+const mockGetRecruiterWithCompany = vi.fn();
+const mockCanManageMembers = vi.fn();
+vi.mock("@/lib/company", () => ({
+  getRecruiterWithCompany: (...args: unknown[]) =>
+    mockGetRecruiterWithCompany(...args),
+  canManageMembers: (...args: unknown[]) => mockCanManageMembers(...args),
+}));
+
+// ── Constants ──────────────────────────────────────────────────────
+
+const RECRUITER_ID = "recruiter-001";
+const TARGET_ID = "recruiter-002";
+const COMPANY_ID = "company-001";
+const ACCOUNT_ID = "acc-1";
+const TARGET_ACCOUNT_ID = "acc-2";
+
+const ownerSession = {
+  user: {
+    accountId: ACCOUNT_ID,
+    recruiterId: RECRUITER_ID,
+    companyId: COMPANY_ID,
+    accountType: "RECRUITER",
+    recruiterStatus: "ACTIVE",
+  },
+};
+
+const mockCompanyData = {
+  company: { id: COMPANY_ID, name: "テスト企業" },
+  recruiter: { id: RECRUITER_ID, role: "OWNER", companyId: COMPANY_ID },
+};
+
+const mockTarget = {
+  id: TARGET_ID,
+  accountId: TARGET_ACCOUNT_ID,
+  role: "ADMIN",
+  status: "ACTIVE",
+  companyId: COMPANY_ID,
+  account: { id: TARGET_ACCOUNT_ID, email: "target@example.com" },
+};
+
+const routeContext = {
+  params: Promise.resolve({ id: TARGET_ID }),
+};
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function createPatchRequest(body: unknown): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/recruiter/members/${TARGET_ID}`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+function createDeleteRequest(): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/recruiter/members/${TARGET_ID}`,
+    { method: "DELETE" },
+  );
+}
+
+// ── PATCH Tests ────────────────────────────────────────────────────
+
+describe("PATCH /api/recruiter/members/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(ownerSession);
+    mockGetRecruiterWithCompany.mockResolvedValue(mockCompanyData);
+    mockCanManageMembers.mockReturnValue(true);
+    mockPrisma.recruiter.findFirst.mockResolvedValue(mockTarget);
+    mockPrisma.recruiter.updateMany.mockResolvedValue({ count: 1 });
+  });
+
+  it("メンバーのステータスを更新できる", async () => {
+    const { PATCH } = await import("@/app/api/recruiter/members/[id]/route");
+    const response = await PATCH(
+      createPatchRequest({ status: "DISABLED" }),
+      routeContext,
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.id).toBe(TARGET_ID);
+    expect(data.status).toBe("DISABLED");
+  });
+
+  it("同じcompanyIdのメンバーのみ取得する", async () => {
+    const { PATCH } = await import("@/app/api/recruiter/members/[id]/route");
+    await PATCH(createPatchRequest({ status: "DISABLED" }), routeContext);
+
+    expect(mockPrisma.recruiter.findFirst).toHaveBeenCalledWith({
+      where: { id: TARGET_ID, companyId: COMPANY_ID },
+      include: { account: true },
+    });
+  });
+
+  it("ステータスが同じ場合は更新せず返す", async () => {
+    const { PATCH } = await import("@/app/api/recruiter/members/[id]/route");
+    const response = await PATCH(
+      createPatchRequest({ status: "ACTIVE" }),
+      routeContext,
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.status).toBe("ACTIVE");
+    expect(mockPrisma.recruiter.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("未認証の場合401を返す", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const { PATCH } = await import("@/app/api/recruiter/members/[id]/route");
+    const response = await PATCH(
+      createPatchRequest({ status: "DISABLED" }),
+      routeContext,
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("権限がない場合403を返す", async () => {
+    mockCanManageMembers.mockReturnValue(false);
+
+    const { PATCH } = await import("@/app/api/recruiter/members/[id]/route");
+    const response = await PATCH(
+      createPatchRequest({ status: "DISABLED" }),
+      routeContext,
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("対象メンバーが見つからない場合404を返す", async () => {
+    mockPrisma.recruiter.findFirst.mockResolvedValue(null);
+
+    const { PATCH } = await import("@/app/api/recruiter/members/[id]/route");
+    const response = await PATCH(
+      createPatchRequest({ status: "DISABLED" }),
+      routeContext,
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it("自分自身のステータスは変更できない", async () => {
+    mockPrisma.recruiter.findFirst.mockResolvedValue({
+      ...mockTarget,
+      accountId: ACCOUNT_ID, // 自分自身
+    });
+
+    const { PATCH } = await import("@/app/api/recruiter/members/[id]/route");
+    const response = await PATCH(
+      createPatchRequest({ status: "DISABLED" }),
+      routeContext,
+    );
+
+    expect(response.status).toBe(409);
+    expect(mockPrisma.recruiter.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("非OWNERがOWNERのステータスを変更できない", async () => {
+    mockGetRecruiterWithCompany.mockResolvedValue({
+      ...mockCompanyData,
+      recruiter: { ...mockCompanyData.recruiter, role: "ADMIN" },
+    });
+    mockPrisma.recruiter.findFirst.mockResolvedValue({
+      ...mockTarget,
+      role: "OWNER",
+    });
+
+    const { PATCH } = await import("@/app/api/recruiter/members/[id]/route");
+    const response = await PATCH(
+      createPatchRequest({ status: "DISABLED" }),
+      routeContext,
+    );
+
+    expect(response.status).toBe(403);
+    expect(mockPrisma.recruiter.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("OWNERは他のOWNERのステータスを変更できる", async () => {
+    mockPrisma.recruiter.findFirst.mockResolvedValue({
+      ...mockTarget,
+      role: "OWNER",
+    });
+
+    const { PATCH } = await import("@/app/api/recruiter/members/[id]/route");
+    const response = await PATCH(
+      createPatchRequest({ status: "DISABLED" }),
+      routeContext,
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  it("条件付きupdateManyで更新する（TOCTOU防止）", async () => {
+    const { PATCH } = await import("@/app/api/recruiter/members/[id]/route");
+    await PATCH(createPatchRequest({ status: "DISABLED" }), routeContext);
+
+    expect(mockPrisma.recruiter.updateMany).toHaveBeenCalledWith({
+      where: { id: TARGET_ID, companyId: COMPANY_ID, status: "ACTIVE" },
+      data: { status: "DISABLED" },
+    });
+  });
+
+  it("同時リクエストでステータス変更済みなら409を返す", async () => {
+    mockPrisma.recruiter.updateMany.mockResolvedValue({ count: 0 });
+
+    const { PATCH } = await import("@/app/api/recruiter/members/[id]/route");
+    const response = await PATCH(
+      createPatchRequest({ status: "DISABLED" }),
+      routeContext,
+    );
+
+    expect(response.status).toBe(409);
+  });
+
+  it("無効なステータスで400を返す", async () => {
+    const { PATCH } = await import("@/app/api/recruiter/members/[id]/route");
+    const response = await PATCH(
+      createPatchRequest({ status: "INVALID" }),
+      routeContext,
+    );
+
+    expect(response.status).toBe(400);
+  });
+});
+
+// ── DELETE Tests ────────────────────────────────────────────────────
+
+describe("DELETE /api/recruiter/members/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(ownerSession);
+    mockGetRecruiterWithCompany.mockResolvedValue(mockCompanyData);
+    mockCanManageMembers.mockReturnValue(true);
+    mockPrisma.recruiter.findFirst.mockResolvedValue(mockTarget);
+    mockPrisma.recruiter.updateMany.mockResolvedValue({ count: 1 });
+  });
+
+  it("メンバーをソフトデリート（DISABLED）できる", async () => {
+    const { DELETE } = await import("@/app/api/recruiter/members/[id]/route");
+    const response = await DELETE(createDeleteRequest(), routeContext);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.status).toBe("DISABLED");
+    expect(mockPrisma.recruiter.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: TARGET_ID,
+        companyId: COMPANY_ID,
+        status: { not: "DISABLED" },
+      },
+      data: { status: "DISABLED" },
+    });
+  });
+
+  it("同じcompanyIdのメンバーのみ対象にする", async () => {
+    const { DELETE } = await import("@/app/api/recruiter/members/[id]/route");
+    await DELETE(createDeleteRequest(), routeContext);
+
+    expect(mockPrisma.recruiter.findFirst).toHaveBeenCalledWith({
+      where: { id: TARGET_ID, companyId: COMPANY_ID },
+      include: { account: true },
+    });
+  });
+
+  it("未認証の場合401を返す", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const { DELETE } = await import("@/app/api/recruiter/members/[id]/route");
+    const response = await DELETE(createDeleteRequest(), routeContext);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("権限がない場合403を返す", async () => {
+    mockCanManageMembers.mockReturnValue(false);
+
+    const { DELETE } = await import("@/app/api/recruiter/members/[id]/route");
+    const response = await DELETE(createDeleteRequest(), routeContext);
+
+    expect(response.status).toBe(403);
+  });
+
+  it("対象メンバーが見つからない場合404を返す", async () => {
+    mockPrisma.recruiter.findFirst.mockResolvedValue(null);
+
+    const { DELETE } = await import("@/app/api/recruiter/members/[id]/route");
+    const response = await DELETE(createDeleteRequest(), routeContext);
+
+    expect(response.status).toBe(404);
+    expect(mockPrisma.recruiter.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("自分自身は削除できない", async () => {
+    mockPrisma.recruiter.findFirst.mockResolvedValue({
+      ...mockTarget,
+      accountId: ACCOUNT_ID,
+    });
+
+    const { DELETE } = await import("@/app/api/recruiter/members/[id]/route");
+    const response = await DELETE(createDeleteRequest(), routeContext);
+
+    expect(response.status).toBe(409);
+    expect(mockPrisma.recruiter.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("同時リクエストで既にDISABLEDなら409を返す", async () => {
+    mockPrisma.recruiter.updateMany.mockResolvedValue({ count: 0 });
+
+    const { DELETE } = await import("@/app/api/recruiter/members/[id]/route");
+    const response = await DELETE(createDeleteRequest(), routeContext);
+
+    expect(response.status).toBe(409);
+  });
+
+  it("非OWNERがOWNERを削除できない", async () => {
+    mockGetRecruiterWithCompany.mockResolvedValue({
+      ...mockCompanyData,
+      recruiter: { ...mockCompanyData.recruiter, role: "ADMIN" },
+    });
+    mockPrisma.recruiter.findFirst.mockResolvedValue({
+      ...mockTarget,
+      role: "OWNER",
+    });
+
+    const { DELETE } = await import("@/app/api/recruiter/members/[id]/route");
+    const response = await DELETE(createDeleteRequest(), routeContext);
+
+    expect(response.status).toBe(403);
+    expect(mockPrisma.recruiter.updateMany).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/recruiter/members/route.ts
+++ b/src/app/api/recruiter/members/route.ts
@@ -30,8 +30,6 @@ export const GET = withAuth(async (_req, session) => {
     orderBy: { createdAt: "desc" },
   });
 
-  const baseUrl = process.env.NEXTAUTH_URL || "http://localhost:3000";
-
   return NextResponse.json({
     company: {
       id: company.id,
@@ -48,14 +46,16 @@ export const GET = withAuth(async (_req, session) => {
       createdAt: m.createdAt,
       joinedAt: m.joinedAt,
     })),
-    invites: invites.map((inv) => ({
-      id: inv.id,
-      email: inv.email,
-      role: inv.role,
-      status: inv.status,
-      expiresAt: inv.expiresAt,
-      createdAt: inv.createdAt,
-      acceptUrl: `${baseUrl}/invite/${inv.token}`,
-    })),
+    invites:
+      recruiter.role === "OWNER" || recruiter.role === "ADMIN"
+        ? invites.map((inv) => ({
+            id: inv.id,
+            email: inv.email,
+            role: inv.role,
+            status: inv.status,
+            expiresAt: inv.expiresAt,
+            createdAt: inv.createdAt,
+          }))
+        : [],
   });
 });

--- a/src/app/api/recruiter/pipeline/[id]/__tests__/pipeline-id.test.ts
+++ b/src/app/api/recruiter/pipeline/[id]/__tests__/pipeline-id.test.ts
@@ -1,0 +1,385 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// NextAuth モック
+const mockGetServerSession = vi.fn();
+vi.mock("next-auth", () => ({
+  getServerSession: () => mockGetServerSession(),
+}));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+
+// Logger モック
+const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+vi.mock("@/lib/logger", () => ({ logger: mockLogger }));
+
+// Prisma トランザクション用クライアント
+const mockTxClient = {
+  candidatePipeline: {
+    findFirst: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+  companyAccess: { findUnique: vi.fn() },
+  pipelineHistory: { create: vi.fn() },
+};
+
+// Prisma メインクライアント
+const mockPrisma = {
+  candidatePipeline: { findFirst: vi.fn() },
+  session: { findMany: vi.fn() },
+  companyAccess: { findUnique: vi.fn() },
+  $transaction: vi.fn(),
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+// access-control（GET用）
+const mockIsCompanyAccessDenied = vi.fn();
+vi.mock("@/lib/access-control", () => ({
+  isCompanyAccessDenied: (...args: unknown[]) =>
+    mockIsCompanyAccessDenied(...args),
+}));
+
+const PIPELINE_ID = "pipeline-001";
+const RECRUITER_ID = "recruiter-001";
+const COMPANY_ID = "company-001";
+const AGENT_USER_ID = "user-agent-001";
+
+const recruiterSession = {
+  user: {
+    accountId: "acc-1",
+    recruiterId: RECRUITER_ID,
+    companyId: COMPANY_ID,
+    accountType: "RECRUITER",
+    recruiterStatus: "ACTIVE",
+  },
+};
+
+const routeContext = {
+  params: Promise.resolve({ id: PIPELINE_ID }),
+};
+
+const mockPipeline = {
+  id: PIPELINE_ID,
+  recruiterId: RECRUITER_ID,
+  agentId: "agent-001",
+  stage: "INTERESTED",
+  note: null,
+  agent: {
+    userId: AGENT_USER_ID,
+    user: { name: "テスト太郎" },
+  },
+  job: { id: "job-001", title: "テスト求人" },
+  history: [],
+};
+
+function createPatchRequest(body: unknown): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/recruiter/pipeline/${PIPELINE_ID}`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+function createDeleteRequest(): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/recruiter/pipeline/${PIPELINE_ID}`,
+    { method: "DELETE" },
+  );
+}
+
+describe("PATCH /api/recruiter/pipeline/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(recruiterSession);
+    mockTxClient.candidatePipeline.findFirst.mockResolvedValue(mockPipeline);
+    mockTxClient.companyAccess.findUnique.mockResolvedValue(null);
+    mockTxClient.pipelineHistory.create.mockResolvedValue({});
+    mockTxClient.candidatePipeline.update.mockResolvedValue({
+      ...mockPipeline,
+      stage: "CONTACTED",
+      history: [
+        {
+          fromStage: "INTERESTED",
+          toStage: "CONTACTED",
+          createdAt: new Date(),
+        },
+      ],
+    });
+    mockPrisma.$transaction.mockImplementation(
+      async (callback: (tx: typeof mockTxClient) => Promise<unknown>) => {
+        return callback(mockTxClient);
+      },
+    );
+  });
+
+  describe("認証", () => {
+    it("未認証の場合は401を返す", async () => {
+      mockGetServerSession.mockResolvedValue(null);
+      const { PATCH } = await import("@/app/api/recruiter/pipeline/[id]/route");
+
+      const res = await PATCH(
+        createPatchRequest({ stage: "CONTACTED" }),
+        routeContext,
+      );
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("バリデーション", () => {
+    it("無効なステージは400を返す", async () => {
+      const { PATCH } = await import("@/app/api/recruiter/pipeline/[id]/route");
+
+      const res = await PATCH(
+        createPatchRequest({ stage: "INVALID" }),
+        routeContext,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("noteが5000文字を超える場合は400を返す", async () => {
+      const { PATCH } = await import("@/app/api/recruiter/pipeline/[id]/route");
+
+      const res = await PATCH(
+        createPatchRequest({ note: "a".repeat(5001) }),
+        routeContext,
+      );
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("状態チェック", () => {
+    it("存在しないパイプラインは404を返す", async () => {
+      mockTxClient.candidatePipeline.findFirst.mockResolvedValue(null);
+      const { PATCH } = await import("@/app/api/recruiter/pipeline/[id]/route");
+
+      const res = await PATCH(
+        createPatchRequest({ stage: "CONTACTED" }),
+        routeContext,
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it("アクセス拒否されている場合は403を返す", async () => {
+      mockTxClient.companyAccess.findUnique.mockResolvedValue({
+        status: "DENY",
+      });
+      const { PATCH } = await import("@/app/api/recruiter/pipeline/[id]/route");
+
+      const res = await PATCH(
+        createPatchRequest({ stage: "CONTACTED" }),
+        routeContext,
+      );
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("正常系", () => {
+    it("ステージ変更が成功する", async () => {
+      const { PATCH } = await import("@/app/api/recruiter/pipeline/[id]/route");
+
+      const res = await PATCH(
+        createPatchRequest({ stage: "CONTACTED" }),
+        routeContext,
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.pipeline).toBeDefined();
+    });
+
+    it("noteのみの更新が成功する", async () => {
+      mockTxClient.candidatePipeline.update.mockResolvedValue({
+        ...mockPipeline,
+        note: "メモ更新",
+      });
+      const { PATCH } = await import("@/app/api/recruiter/pipeline/[id]/route");
+
+      const res = await PATCH(
+        createPatchRequest({ note: "メモ更新" }),
+        routeContext,
+      );
+      expect(res.status).toBe(200);
+      // noteだけの場合はhistory作成されない
+      expect(mockTxClient.pipelineHistory.create).not.toHaveBeenCalled();
+    });
+
+    it("ステージ変更時に履歴が記録される", async () => {
+      const { PATCH } = await import("@/app/api/recruiter/pipeline/[id]/route");
+
+      await PATCH(createPatchRequest({ stage: "CONTACTED" }), routeContext);
+
+      expect(mockTxClient.pipelineHistory.create).toHaveBeenCalledWith({
+        data: {
+          pipelineId: PIPELINE_ID,
+          fromStage: "INTERESTED",
+          toStage: "CONTACTED",
+          note: undefined,
+        },
+      });
+    });
+
+    it("同じステージへの変更では履歴は作成されない", async () => {
+      const { PATCH } = await import("@/app/api/recruiter/pipeline/[id]/route");
+
+      await PATCH(createPatchRequest({ stage: "INTERESTED" }), routeContext);
+
+      expect(mockTxClient.pipelineHistory.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("TOCTOU防止", () => {
+    it("トランザクション内でパイプラインを取得する", async () => {
+      const { PATCH } = await import("@/app/api/recruiter/pipeline/[id]/route");
+
+      await PATCH(createPatchRequest({ stage: "CONTACTED" }), routeContext);
+
+      // メインクライアントのfindFirstは呼ばれない（txクライアントが呼ばれる）
+      expect(mockPrisma.candidatePipeline.findFirst).not.toHaveBeenCalled();
+      expect(mockTxClient.candidatePipeline.findFirst).toHaveBeenCalledWith({
+        where: {
+          id: PIPELINE_ID,
+          recruiterId: RECRUITER_ID,
+        },
+        include: {
+          agent: {
+            select: { userId: true },
+          },
+        },
+      });
+    });
+
+    it("トランザクション内でアクセスチェックする", async () => {
+      const { PATCH } = await import("@/app/api/recruiter/pipeline/[id]/route");
+
+      await PATCH(createPatchRequest({ stage: "CONTACTED" }), routeContext);
+
+      expect(mockTxClient.companyAccess.findUnique).toHaveBeenCalledWith({
+        where: {
+          userId_companyId: {
+            userId: AGENT_USER_ID,
+            companyId: COMPANY_ID,
+          },
+        },
+        select: { status: true },
+      });
+    });
+
+    it("ALLOWステータスではアクセス許可される", async () => {
+      mockTxClient.companyAccess.findUnique.mockResolvedValue({
+        status: "ALLOW",
+      });
+      const { PATCH } = await import("@/app/api/recruiter/pipeline/[id]/route");
+
+      const res = await PATCH(
+        createPatchRequest({ stage: "CONTACTED" }),
+        routeContext,
+      );
+      expect(res.status).toBe(200);
+    });
+  });
+});
+
+describe("DELETE /api/recruiter/pipeline/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(recruiterSession);
+    mockTxClient.candidatePipeline.findFirst.mockResolvedValue(mockPipeline);
+    mockTxClient.companyAccess.findUnique.mockResolvedValue(null);
+    mockTxClient.candidatePipeline.delete.mockResolvedValue({});
+    mockPrisma.$transaction.mockImplementation(
+      async (callback: (tx: typeof mockTxClient) => Promise<unknown>) => {
+        return callback(mockTxClient);
+      },
+    );
+  });
+
+  describe("認証", () => {
+    it("未認証の場合は401を返す", async () => {
+      mockGetServerSession.mockResolvedValue(null);
+      const { DELETE } = await import(
+        "@/app/api/recruiter/pipeline/[id]/route"
+      );
+
+      const res = await DELETE(createDeleteRequest(), routeContext);
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("状態チェック", () => {
+    it("存在しないパイプラインは404を返す", async () => {
+      mockTxClient.candidatePipeline.findFirst.mockResolvedValue(null);
+      const { DELETE } = await import(
+        "@/app/api/recruiter/pipeline/[id]/route"
+      );
+
+      const res = await DELETE(createDeleteRequest(), routeContext);
+      expect(res.status).toBe(404);
+    });
+
+    it("アクセス拒否されている場合は403を返す", async () => {
+      mockTxClient.companyAccess.findUnique.mockResolvedValue({
+        status: "DENY",
+      });
+      const { DELETE } = await import(
+        "@/app/api/recruiter/pipeline/[id]/route"
+      );
+
+      const res = await DELETE(createDeleteRequest(), routeContext);
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("正常系", () => {
+    it("削除が成功する", async () => {
+      const { DELETE } = await import(
+        "@/app/api/recruiter/pipeline/[id]/route"
+      );
+
+      const res = await DELETE(createDeleteRequest(), routeContext);
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.success).toBe(true);
+    });
+
+    it("正しいIDで削除される", async () => {
+      const { DELETE } = await import(
+        "@/app/api/recruiter/pipeline/[id]/route"
+      );
+
+      await DELETE(createDeleteRequest(), routeContext);
+
+      expect(mockTxClient.candidatePipeline.delete).toHaveBeenCalledWith({
+        where: { id: PIPELINE_ID },
+      });
+    });
+  });
+
+  describe("TOCTOU防止", () => {
+    it("トランザクション内でパイプラインを取得・検証・削除する", async () => {
+      const { DELETE } = await import(
+        "@/app/api/recruiter/pipeline/[id]/route"
+      );
+
+      await DELETE(createDeleteRequest(), routeContext);
+
+      // メインクライアントのfindFirstは呼ばれない
+      expect(mockPrisma.candidatePipeline.findFirst).not.toHaveBeenCalled();
+      // txクライアントでfindFirstが呼ばれる
+      expect(mockTxClient.candidatePipeline.findFirst).toHaveBeenCalled();
+      // txクライアントでアクセスチェック
+      expect(mockTxClient.companyAccess.findUnique).toHaveBeenCalledWith({
+        where: {
+          userId_companyId: {
+            userId: AGENT_USER_ID,
+            companyId: COMPANY_ID,
+          },
+        },
+        select: { status: true },
+      });
+      // txクライアントで削除
+      expect(mockTxClient.candidatePipeline.delete).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/api/recruiter/pipeline/__tests__/pipeline-post.test.ts
+++ b/src/app/api/recruiter/pipeline/__tests__/pipeline-post.test.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -170,9 +171,10 @@ describe("POST /api/recruiter/pipeline", () => {
     });
 
     it("P2002ユニーク制約違反は409を返す", async () => {
-      const p2002Error = Object.assign(new Error("Unique constraint failed"), {
-        code: "P2002",
-      });
+      const p2002Error = new Prisma.PrismaClientKnownRequestError(
+        "Unique constraint failed",
+        { code: "P2002", clientVersion: "6.0.0" },
+      );
       mockPrisma.$transaction.mockRejectedValue(p2002Error);
       const { POST } = await import("@/app/api/recruiter/pipeline/route");
 

--- a/src/app/api/recruiter/pipeline/__tests__/pipeline-post.test.ts
+++ b/src/app/api/recruiter/pipeline/__tests__/pipeline-post.test.ts
@@ -1,0 +1,274 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// NextAuth モック
+const mockGetServerSession = vi.fn();
+vi.mock("next-auth", () => ({
+  getServerSession: () => mockGetServerSession(),
+}));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+
+// Logger モック
+const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+vi.mock("@/lib/logger", () => ({ logger: mockLogger }));
+
+// トランザクション用クライアント
+const mockTxClient = {
+  candidatePipeline: {
+    findFirst: vi.fn(),
+    create: vi.fn(),
+  },
+};
+
+// Prisma メインクライアント
+const mockPrisma = {
+  candidatePipeline: { findMany: vi.fn() },
+  agentProfile: { findFirst: vi.fn() },
+  jobPosting: { findFirst: vi.fn() },
+  $transaction: vi.fn(),
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+// access-control
+const mockIsCompanyAccessDenied = vi.fn();
+vi.mock("@/lib/access-control", () => ({
+  isCompanyAccessDenied: (...args: unknown[]) =>
+    mockIsCompanyAccessDenied(...args),
+}));
+
+const RECRUITER_ID = "recruiter-001";
+const COMPANY_ID = "company-001";
+const AGENT_ID = "agent-001";
+const AGENT_USER_ID = "user-001";
+const JOB_ID = "job-001";
+
+const recruiterSession = {
+  user: {
+    accountId: "acc-1",
+    recruiterId: RECRUITER_ID,
+    companyId: COMPANY_ID,
+    accountType: "RECRUITER",
+    recruiterStatus: "ACTIVE",
+  },
+};
+
+const mockAgent = {
+  id: AGENT_ID,
+  userId: AGENT_USER_ID,
+  status: "PUBLIC",
+};
+
+const mockCreatedPipeline = {
+  id: "pipeline-001",
+  recruiterId: RECRUITER_ID,
+  agentId: AGENT_ID,
+  jobId: null,
+  stage: "INTERESTED",
+  agent: { user: { name: "テスト太郎" } },
+  job: null,
+};
+
+function createPostRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/recruiter/pipeline", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/recruiter/pipeline", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(recruiterSession);
+    mockPrisma.agentProfile.findFirst.mockResolvedValue(mockAgent);
+    mockIsCompanyAccessDenied.mockResolvedValue(false);
+    mockTxClient.candidatePipeline.findFirst.mockResolvedValue(null);
+    mockTxClient.candidatePipeline.create.mockResolvedValue(
+      mockCreatedPipeline,
+    );
+    mockPrisma.$transaction.mockImplementation(
+      async (callback: (tx: typeof mockTxClient) => Promise<unknown>) => {
+        return callback(mockTxClient);
+      },
+    );
+  });
+
+  describe("認証", () => {
+    it("未認証の場合は401を返す", async () => {
+      mockGetServerSession.mockResolvedValue(null);
+      const { POST } = await import("@/app/api/recruiter/pipeline/route");
+
+      const res = await POST(createPostRequest({ agentId: AGENT_ID }));
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("バリデーション", () => {
+    it("agentIdが空の場合は400を返す", async () => {
+      const { POST } = await import("@/app/api/recruiter/pipeline/route");
+
+      const res = await POST(createPostRequest({ agentId: "" }));
+      expect(res.status).toBe(400);
+    });
+
+    it("noteが5000文字を超える場合は400を返す", async () => {
+      const { POST } = await import("@/app/api/recruiter/pipeline/route");
+
+      const res = await POST(
+        createPostRequest({ agentId: AGENT_ID, note: "a".repeat(5001) }),
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("無効なステージは400を返す", async () => {
+      const { POST } = await import("@/app/api/recruiter/pipeline/route");
+
+      const res = await POST(
+        createPostRequest({ agentId: AGENT_ID, stage: "INVALID" }),
+      );
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("状態チェック", () => {
+    it("存在しないエージェントは404を返す", async () => {
+      mockPrisma.agentProfile.findFirst.mockResolvedValue(null);
+      const { POST } = await import("@/app/api/recruiter/pipeline/route");
+
+      const res = await POST(createPostRequest({ agentId: AGENT_ID }));
+      expect(res.status).toBe(404);
+    });
+
+    it("アクセス拒否の場合は403を返す", async () => {
+      mockIsCompanyAccessDenied.mockResolvedValue(true);
+      const { POST } = await import("@/app/api/recruiter/pipeline/route");
+
+      const res = await POST(createPostRequest({ agentId: AGENT_ID }));
+      expect(res.status).toBe(403);
+    });
+
+    it("存在しない求人は404を返す", async () => {
+      mockPrisma.jobPosting.findFirst.mockResolvedValue(null);
+      const { POST } = await import("@/app/api/recruiter/pipeline/route");
+
+      const res = await POST(
+        createPostRequest({ agentId: AGENT_ID, jobId: JOB_ID }),
+      );
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("重複チェック", () => {
+    it("既存パイプラインがある場合は409を返す", async () => {
+      mockTxClient.candidatePipeline.findFirst.mockResolvedValue({
+        id: "existing-pipeline",
+      });
+      const { POST } = await import("@/app/api/recruiter/pipeline/route");
+
+      const res = await POST(createPostRequest({ agentId: AGENT_ID }));
+      expect(res.status).toBe(409);
+    });
+
+    it("P2002ユニーク制約違反は409を返す", async () => {
+      const p2002Error = Object.assign(new Error("Unique constraint failed"), {
+        code: "P2002",
+      });
+      mockPrisma.$transaction.mockRejectedValue(p2002Error);
+      const { POST } = await import("@/app/api/recruiter/pipeline/route");
+
+      const res = await POST(createPostRequest({ agentId: AGENT_ID }));
+      expect(res.status).toBe(409);
+    });
+  });
+
+  describe("正常系", () => {
+    it("パイプラインが正常に作成される", async () => {
+      const { POST } = await import("@/app/api/recruiter/pipeline/route");
+
+      const res = await POST(createPostRequest({ agentId: AGENT_ID }));
+      expect(res.status).toBe(201);
+      const data = await res.json();
+      expect(data.pipeline).toBeDefined();
+    });
+
+    it("デフォルトステージはINTERESTEDになる", async () => {
+      const { POST } = await import("@/app/api/recruiter/pipeline/route");
+
+      await POST(createPostRequest({ agentId: AGENT_ID }));
+
+      expect(mockTxClient.candidatePipeline.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            stage: "INTERESTED",
+          }),
+        }),
+      );
+    });
+
+    it("カスタムステージが指定できる", async () => {
+      const { POST } = await import("@/app/api/recruiter/pipeline/route");
+
+      await POST(createPostRequest({ agentId: AGENT_ID, stage: "SCREENING" }));
+
+      expect(mockTxClient.candidatePipeline.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            stage: "SCREENING",
+          }),
+        }),
+      );
+    });
+
+    it("求人IDとnoteが指定できる", async () => {
+      mockPrisma.jobPosting.findFirst.mockResolvedValue({ id: JOB_ID });
+      const { POST } = await import("@/app/api/recruiter/pipeline/route");
+
+      await POST(
+        createPostRequest({
+          agentId: AGENT_ID,
+          jobId: JOB_ID,
+          note: "良い候補者",
+        }),
+      );
+
+      expect(mockTxClient.candidatePipeline.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            jobId: JOB_ID,
+            note: "良い候補者",
+          }),
+        }),
+      );
+    });
+  });
+
+  describe("TOCTOU防止", () => {
+    it("トランザクション内で重複チェックと作成を行う", async () => {
+      const { POST } = await import("@/app/api/recruiter/pipeline/route");
+
+      await POST(createPostRequest({ agentId: AGENT_ID }));
+
+      // メインクライアントではなくtxクライアントでfindFirstが呼ばれる
+      expect(mockTxClient.candidatePipeline.findFirst).toHaveBeenCalledWith({
+        where: {
+          recruiterId: RECRUITER_ID,
+          agentId: AGENT_ID,
+          jobId: null,
+        },
+      });
+      // txクライアントでcreateが呼ばれる
+      expect(mockTxClient.candidatePipeline.create).toHaveBeenCalled();
+    });
+
+    it("トランザクション内で重複検出するとcreateは呼ばれない", async () => {
+      mockTxClient.candidatePipeline.findFirst.mockResolvedValue({
+        id: "existing",
+      });
+      const { POST } = await import("@/app/api/recruiter/pipeline/route");
+
+      await POST(createPostRequest({ agentId: AGENT_ID }));
+
+      expect(mockTxClient.candidatePipeline.create).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/api/recruiter/pipeline/route.ts
+++ b/src/app/api/recruiter/pipeline/route.ts
@@ -1,4 +1,4 @@
-import type { PipelineStage } from "@prisma/client";
+import { type PipelineStage, Prisma } from "@prisma/client";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { isCompanyAccessDenied } from "@/lib/access-control";
@@ -203,8 +203,10 @@ export const POST = withRecruiterAuth(async (req, session) => {
     return NextResponse.json({ pipeline }, { status: 201 });
   } catch (error) {
     // jobIdがnon-nullの場合、ユニーク制約違反で重複を検出
-    const prismaError = error as { code?: string };
-    if (prismaError.code === "P2002") {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
       throw new ConflictError("この候補者は既にパイプラインに追加されています");
     }
     throw error;

--- a/src/app/api/recruiter/pipeline/route.ts
+++ b/src/app/api/recruiter/pipeline/route.ts
@@ -67,6 +67,7 @@ export const GET = withRecruiterAuth(async (req, session) => {
       },
     },
     orderBy: { updatedAt: "desc" },
+    take: 200,
   });
 
   // ステージ別にグループ化

--- a/src/app/api/recruiter/sessions/route.ts
+++ b/src/app/api/recruiter/sessions/route.ts
@@ -47,6 +47,7 @@ export const GET = withRecruiterAuth(async (req, session) => {
       },
     },
     orderBy: { createdAt: "desc" },
+    take: 100,
   });
 
   return NextResponse.json({ sessions, totalCount: sessions.length });

--- a/src/app/api/recruiter/watches/[id]/__tests__/watch-manage.test.ts
+++ b/src/app/api/recruiter/watches/[id]/__tests__/watch-manage.test.ts
@@ -1,0 +1,350 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mocks ──────────────────────────────────────────────────────────
+
+const mockGetServerSession = vi.fn();
+vi.mock("next-auth", () => ({
+  getServerSession: () => mockGetServerSession(),
+}));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+
+const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+vi.mock("@/lib/logger", () => ({ logger: mockLogger }));
+
+const mockPrisma = {
+  candidateWatch: {
+    findFirst: vi.fn(),
+    updateMany: vi.fn(),
+    deleteMany: vi.fn(),
+  },
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+// ── Constants ──────────────────────────────────────────────────────
+
+const RECRUITER_ID = "recruiter-001";
+const COMPANY_ID = "company-001";
+const ACCOUNT_ID = "acc-1";
+const WATCH_ID = "watch-001";
+const JOB_ID = "job-001";
+
+const recruiterSession = {
+  user: {
+    accountId: ACCOUNT_ID,
+    recruiterId: RECRUITER_ID,
+    companyId: COMPANY_ID,
+    accountType: "RECRUITER",
+    recruiterStatus: "ACTIVE",
+  },
+};
+
+const mockWatch = {
+  id: WATCH_ID,
+  recruiterId: RECRUITER_ID,
+  jobId: JOB_ID,
+  name: "フロントエンドエンジニア",
+  skills: ["React", "TypeScript"],
+  keywords: ["フロントエンド"],
+  experienceLevel: "MID",
+  locationPref: "東京",
+  salaryMin: 5000000,
+  isActive: true,
+  createdAt: new Date("2024-01-01"),
+  updatedAt: new Date("2024-01-01"),
+};
+
+const mockWatchWithRelations = {
+  ...mockWatch,
+  job: { id: JOB_ID, title: "フロントエンドエンジニア募集" },
+  notifications: [],
+};
+
+const routeContext = {
+  params: Promise.resolve({ id: WATCH_ID }),
+};
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function createGetRequest(): NextRequest {
+  return new NextRequest(`http://localhost/api/recruiter/watches/${WATCH_ID}`, {
+    method: "GET",
+  });
+}
+
+function createPatchRequest(body: unknown): NextRequest {
+  return new NextRequest(`http://localhost/api/recruiter/watches/${WATCH_ID}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function createDeleteRequest(): NextRequest {
+  return new NextRequest(`http://localhost/api/recruiter/watches/${WATCH_ID}`, {
+    method: "DELETE",
+  });
+}
+
+// ── GET Tests ──────────────────────────────────────────────────────
+
+describe("GET /api/recruiter/watches/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(recruiterSession);
+  });
+
+  it("ウォッチリスト詳細を返す", async () => {
+    mockPrisma.candidateWatch.findFirst.mockResolvedValue(
+      mockWatchWithRelations,
+    );
+
+    const { GET } = await import("@/app/api/recruiter/watches/[id]/route");
+    const response = await GET(createGetRequest(), routeContext);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.watch.id).toBe(WATCH_ID);
+    expect(data.watch.name).toBe("フロントエンドエンジニア");
+    expect(data.watch.job.title).toBe("フロントエンドエンジニア募集");
+  });
+
+  it("自分のrecruiterIdでフィルタする", async () => {
+    mockPrisma.candidateWatch.findFirst.mockResolvedValue(
+      mockWatchWithRelations,
+    );
+
+    const { GET } = await import("@/app/api/recruiter/watches/[id]/route");
+    await GET(createGetRequest(), routeContext);
+
+    expect(mockPrisma.candidateWatch.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: WATCH_ID, recruiterId: RECRUITER_ID },
+      }),
+    );
+  });
+
+  it("存在しないウォッチリストは404を返す", async () => {
+    mockPrisma.candidateWatch.findFirst.mockResolvedValue(null);
+
+    const { GET } = await import("@/app/api/recruiter/watches/[id]/route");
+    const response = await GET(createGetRequest(), routeContext);
+
+    expect(response.status).toBe(404);
+  });
+
+  it("未認証の場合401を返す", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const { GET } = await import("@/app/api/recruiter/watches/[id]/route");
+    const response = await GET(createGetRequest(), routeContext);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("recruiterIdがない場合403を返す", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: {
+        accountId: ACCOUNT_ID,
+        companyId: COMPANY_ID,
+        accountType: "RECRUITER",
+      },
+    });
+
+    const { GET } = await import("@/app/api/recruiter/watches/[id]/route");
+    const response = await GET(createGetRequest(), routeContext);
+
+    expect(response.status).toBe(403);
+  });
+});
+
+// ── PATCH Tests ────────────────────────────────────────────────────
+
+describe("PATCH /api/recruiter/watches/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(recruiterSession);
+    mockPrisma.candidateWatch.findFirst.mockResolvedValue(mockWatch);
+    mockPrisma.candidateWatch.updateMany.mockResolvedValue({ count: 1 });
+  });
+
+  it("ウォッチリストの名前を更新できる", async () => {
+    const updatedWatch = { ...mockWatch, name: "バックエンドエンジニア" };
+    // findFirst is called twice: once for existence check, once for returning updated data
+    mockPrisma.candidateWatch.findFirst
+      .mockResolvedValueOnce(mockWatch)
+      .mockResolvedValueOnce(updatedWatch);
+
+    const { PATCH } = await import("@/app/api/recruiter/watches/[id]/route");
+    const response = await PATCH(
+      createPatchRequest({ name: "バックエンドエンジニア" }),
+      routeContext,
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.watch.name).toBe("バックエンドエンジニア");
+  });
+
+  it("スキルを更新できる", async () => {
+    const updatedWatch = { ...mockWatch, skills: ["Vue", "Nuxt"] };
+    mockPrisma.candidateWatch.findFirst
+      .mockResolvedValueOnce(mockWatch)
+      .mockResolvedValueOnce(updatedWatch);
+
+    const { PATCH } = await import("@/app/api/recruiter/watches/[id]/route");
+    const response = await PATCH(
+      createPatchRequest({ skills: ["Vue", "Nuxt"] }),
+      routeContext,
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.watch.skills).toEqual(["Vue", "Nuxt"]);
+  });
+
+  it("isActiveを更新できる", async () => {
+    const updatedWatch = { ...mockWatch, isActive: false };
+    mockPrisma.candidateWatch.findFirst
+      .mockResolvedValueOnce(mockWatch)
+      .mockResolvedValueOnce(updatedWatch);
+
+    const { PATCH } = await import("@/app/api/recruiter/watches/[id]/route");
+    const response = await PATCH(
+      createPatchRequest({ isActive: false }),
+      routeContext,
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.watch.isActive).toBe(false);
+  });
+
+  it("recruiterId条件付きupdateManyで所有権を検証する（TOCTOU防止）", async () => {
+    mockPrisma.candidateWatch.findFirst
+      .mockResolvedValueOnce(mockWatch)
+      .mockResolvedValueOnce(mockWatch);
+
+    const { PATCH } = await import("@/app/api/recruiter/watches/[id]/route");
+    await PATCH(createPatchRequest({ name: "新しい名前" }), routeContext);
+
+    expect(mockPrisma.candidateWatch.updateMany).toHaveBeenCalledWith({
+      where: { id: WATCH_ID, recruiterId: RECRUITER_ID },
+      data: { name: "新しい名前" },
+    });
+  });
+
+  it("同時リクエストで既に削除済みなら404を返す", async () => {
+    mockPrisma.candidateWatch.updateMany.mockResolvedValue({ count: 0 });
+
+    const { PATCH } = await import("@/app/api/recruiter/watches/[id]/route");
+    const response = await PATCH(
+      createPatchRequest({ name: "新しい名前" }),
+      routeContext,
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it("存在しないウォッチリストは404を返す", async () => {
+    mockPrisma.candidateWatch.findFirst.mockResolvedValue(null);
+
+    const { PATCH } = await import("@/app/api/recruiter/watches/[id]/route");
+    const response = await PATCH(
+      createPatchRequest({ name: "新しい名前" }),
+      routeContext,
+    );
+
+    expect(response.status).toBe(404);
+    expect(mockPrisma.candidateWatch.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("無効なバリデーションで400を返す", async () => {
+    const { PATCH } = await import("@/app/api/recruiter/watches/[id]/route");
+    const response = await PATCH(
+      createPatchRequest({ name: "" }), // min(1)に違反
+      routeContext,
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockPrisma.candidateWatch.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("未認証の場合401を返す", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const { PATCH } = await import("@/app/api/recruiter/watches/[id]/route");
+    const response = await PATCH(
+      createPatchRequest({ name: "新しい名前" }),
+      routeContext,
+    );
+
+    expect(response.status).toBe(401);
+  });
+});
+
+// ── DELETE Tests ────────────────────────────────────────────────────
+
+describe("DELETE /api/recruiter/watches/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(recruiterSession);
+    mockPrisma.candidateWatch.findFirst.mockResolvedValue(mockWatch);
+    mockPrisma.candidateWatch.deleteMany.mockResolvedValue({ count: 1 });
+  });
+
+  it("ウォッチリストを削除できる", async () => {
+    const { DELETE } = await import("@/app/api/recruiter/watches/[id]/route");
+    const response = await DELETE(createDeleteRequest(), routeContext);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+  });
+
+  it("recruiterId条件付きdeleteManyで所有権を検証する（TOCTOU防止）", async () => {
+    const { DELETE } = await import("@/app/api/recruiter/watches/[id]/route");
+    await DELETE(createDeleteRequest(), routeContext);
+
+    expect(mockPrisma.candidateWatch.deleteMany).toHaveBeenCalledWith({
+      where: { id: WATCH_ID, recruiterId: RECRUITER_ID },
+    });
+  });
+
+  it("同時リクエストで既に削除済みなら404を返す", async () => {
+    mockPrisma.candidateWatch.deleteMany.mockResolvedValue({ count: 0 });
+
+    const { DELETE } = await import("@/app/api/recruiter/watches/[id]/route");
+    const response = await DELETE(createDeleteRequest(), routeContext);
+
+    expect(response.status).toBe(404);
+  });
+
+  it("存在しないウォッチリストは404を返す", async () => {
+    mockPrisma.candidateWatch.findFirst.mockResolvedValue(null);
+
+    const { DELETE } = await import("@/app/api/recruiter/watches/[id]/route");
+    const response = await DELETE(createDeleteRequest(), routeContext);
+
+    expect(response.status).toBe(404);
+    expect(mockPrisma.candidateWatch.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("未認証の場合401を返す", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const { DELETE } = await import("@/app/api/recruiter/watches/[id]/route");
+    const response = await DELETE(createDeleteRequest(), routeContext);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("自分のrecruiterIdでフィルタする", async () => {
+    const { DELETE } = await import("@/app/api/recruiter/watches/[id]/route");
+    await DELETE(createDeleteRequest(), routeContext);
+
+    expect(mockPrisma.candidateWatch.findFirst).toHaveBeenCalledWith({
+      where: { id: WATCH_ID, recruiterId: RECRUITER_ID },
+    });
+  });
+});

--- a/src/app/api/recruiter/watches/__tests__/watches.test.ts
+++ b/src/app/api/recruiter/watches/__tests__/watches.test.ts
@@ -1,0 +1,551 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mocks ──────────────────────────────────────────────────────────
+
+const mockGetServerSession = vi.fn();
+vi.mock("next-auth", () => ({
+  getServerSession: () => mockGetServerSession(),
+}));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+
+const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+vi.mock("@/lib/logger", () => ({ logger: mockLogger }));
+
+const mockPrisma = {
+  candidateWatch: {
+    findMany: vi.fn(),
+    findUnique: vi.fn(),
+    create: vi.fn(),
+  },
+  jobPosting: {
+    findFirst: vi.fn(),
+  },
+  agentProfile: {
+    findMany: vi.fn(),
+  },
+  watchNotification: {
+    upsert: vi.fn(),
+  },
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+// ── Constants ──────────────────────────────────────────────────────
+
+const RECRUITER_ID = "recruiter-001";
+const COMPANY_ID = "company-001";
+const ACCOUNT_ID = "acc-001";
+
+const recruiterSession = {
+  user: {
+    accountId: ACCOUNT_ID,
+    recruiterId: RECRUITER_ID,
+    companyId: COMPANY_ID,
+    accountType: "RECRUITER",
+    recruiterStatus: "ACTIVE",
+  },
+};
+
+const mockWatch = {
+  id: "watch-001",
+  recruiterId: RECRUITER_ID,
+  name: "React開発者ウォッチ",
+  jobId: null,
+  skills: ["React", "TypeScript"],
+  keywords: ["フロントエンド"],
+  experienceLevel: "MID",
+  locationPref: "東京",
+  salaryMin: 5000000,
+  isActive: true,
+  createdAt: new Date("2024-01-15"),
+  updatedAt: new Date("2024-01-15"),
+  job: null,
+  _count: { notifications: 5 },
+  notifications: [{ id: "notif-1" }, { id: "notif-2" }],
+};
+
+const mockWatchCreated = {
+  id: "watch-002",
+  recruiterId: RECRUITER_ID,
+  name: "新規ウォッチ",
+  jobId: null,
+  skills: [],
+  keywords: [],
+  experienceLevel: null,
+  locationPref: null,
+  salaryMin: null,
+  isActive: true,
+  createdAt: new Date("2024-01-16"),
+  updatedAt: new Date("2024-01-16"),
+  job: null,
+};
+
+const validBody = {
+  name: "新規ウォッチ",
+};
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function createGetRequest(queryString = ""): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/recruiter/watches${queryString}`,
+    { method: "GET" },
+  );
+}
+
+function createPostRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/recruiter/watches", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// ── GET Tests ──────────────────────────────────────────────────────
+
+describe("GET /api/recruiter/watches", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(recruiterSession);
+  });
+
+  it("ウォッチリスト一覧を返す", async () => {
+    mockPrisma.candidateWatch.findMany.mockResolvedValue([mockWatch]);
+
+    const { GET } = await import("@/app/api/recruiter/watches/route");
+    const response = await GET(createGetRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.watches).toHaveLength(1);
+    expect(data.watches[0].name).toBe("React開発者ウォッチ");
+  });
+
+  it("unreadCountを未読通知数から計算する", async () => {
+    mockPrisma.candidateWatch.findMany.mockResolvedValue([mockWatch]);
+
+    const { GET } = await import("@/app/api/recruiter/watches/route");
+    const response = await GET(createGetRequest());
+    const data = await response.json();
+
+    expect(data.watches[0].unreadCount).toBe(2);
+    expect(data.watches[0]._count.notifications).toBe(5);
+  });
+
+  it("レスポンスからnotifications配列を除去する", async () => {
+    mockPrisma.candidateWatch.findMany.mockResolvedValue([mockWatch]);
+
+    const { GET } = await import("@/app/api/recruiter/watches/route");
+    const response = await GET(createGetRequest());
+    const data = await response.json();
+
+    expect(data.watches[0].notifications).toBeUndefined();
+  });
+
+  it("自分のrecruiterIdでフィルタする", async () => {
+    mockPrisma.candidateWatch.findMany.mockResolvedValue([]);
+
+    const { GET } = await import("@/app/api/recruiter/watches/route");
+    await GET(createGetRequest());
+
+    expect(mockPrisma.candidateWatch.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { recruiterId: RECRUITER_ID },
+      }),
+    );
+  });
+
+  it("createdAtの降順でソートする", async () => {
+    mockPrisma.candidateWatch.findMany.mockResolvedValue([]);
+
+    const { GET } = await import("@/app/api/recruiter/watches/route");
+    await GET(createGetRequest());
+
+    expect(mockPrisma.candidateWatch.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: { createdAt: "desc" },
+      }),
+    );
+  });
+
+  it("job情報をincludeする", async () => {
+    const watchWithJob = {
+      ...mockWatch,
+      jobId: "job-001",
+      job: { id: "job-001", title: "フロントエンドエンジニア" },
+    };
+    mockPrisma.candidateWatch.findMany.mockResolvedValue([watchWithJob]);
+
+    const { GET } = await import("@/app/api/recruiter/watches/route");
+    const response = await GET(createGetRequest());
+    const data = await response.json();
+
+    expect(data.watches[0].job).toEqual({
+      id: "job-001",
+      title: "フロントエンドエンジニア",
+    });
+  });
+
+  it("空のウォッチリストを返す", async () => {
+    mockPrisma.candidateWatch.findMany.mockResolvedValue([]);
+
+    const { GET } = await import("@/app/api/recruiter/watches/route");
+    const response = await GET(createGetRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.watches).toEqual([]);
+  });
+
+  it("未認証の場合401を返す", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const { GET } = await import("@/app/api/recruiter/watches/route");
+    const response = await GET(createGetRequest());
+
+    expect(response.status).toBe(401);
+  });
+
+  it("recruiterIdがない場合403を返す", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { accountId: ACCOUNT_ID, companyId: COMPANY_ID },
+    });
+
+    const { GET } = await import("@/app/api/recruiter/watches/route");
+    const response = await GET(createGetRequest());
+
+    expect(response.status).toBe(403);
+  });
+});
+
+// ── POST Tests ─────────────────────────────────────────────────────
+
+describe("POST /api/recruiter/watches", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(recruiterSession);
+    mockPrisma.candidateWatch.create.mockResolvedValue(mockWatchCreated);
+    // マッチング処理のモック（checkExistingAgentsForWatch）
+    mockPrisma.candidateWatch.findUnique.mockResolvedValue({
+      ...mockWatchCreated,
+      isActive: true,
+      recruiter: { companyId: COMPANY_ID },
+    });
+    mockPrisma.agentProfile.findMany.mockResolvedValue([]);
+  });
+
+  it("ウォッチを作成して201を返す", async () => {
+    const { POST } = await import("@/app/api/recruiter/watches/route");
+    const response = await POST(createPostRequest(validBody));
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.watch).toBeDefined();
+    expect(data.watch.name).toBe("新規ウォッチ");
+  });
+
+  it("recruiterIdを含めて作成する", async () => {
+    const { POST } = await import("@/app/api/recruiter/watches/route");
+    await POST(createPostRequest(validBody));
+
+    expect(mockPrisma.candidateWatch.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          recruiterId: RECRUITER_ID,
+          name: "新規ウォッチ",
+        }),
+      }),
+    );
+  });
+
+  it("全フィールドを含むリクエストで作成できる", async () => {
+    const fullBody = {
+      name: "フルウォッチ",
+      jobId: "job-001",
+      skills: ["React", "TypeScript"],
+      keywords: ["フロントエンド", "SPA"],
+      experienceLevel: "SENIOR",
+      locationPref: "東京・大阪",
+      salaryMin: 8000000,
+    };
+    mockPrisma.jobPosting.findFirst.mockResolvedValue({
+      id: "job-001",
+      recruiterId: RECRUITER_ID,
+    });
+    mockPrisma.candidateWatch.create.mockResolvedValue({
+      ...mockWatchCreated,
+      ...fullBody,
+      job: { id: "job-001", title: "テスト求人" },
+    });
+
+    const { POST } = await import("@/app/api/recruiter/watches/route");
+    const response = await POST(createPostRequest(fullBody));
+
+    expect(response.status).toBe(201);
+    expect(mockPrisma.candidateWatch.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          recruiterId: RECRUITER_ID,
+          name: "フルウォッチ",
+          skills: ["React", "TypeScript"],
+          keywords: ["フロントエンド", "SPA"],
+          experienceLevel: "SENIOR",
+          locationPref: "東京・大阪",
+          salaryMin: 8000000,
+          jobId: "job-001",
+        }),
+      }),
+    );
+  });
+
+  it("デフォルト値が適用される（skills=[], keywords=[]）", async () => {
+    const { POST } = await import("@/app/api/recruiter/watches/route");
+    await POST(createPostRequest(validBody));
+
+    expect(mockPrisma.candidateWatch.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          skills: [],
+          keywords: [],
+        }),
+      }),
+    );
+  });
+
+  it("jobIdが指定された場合、求人の所有権を確認する", async () => {
+    mockPrisma.jobPosting.findFirst.mockResolvedValue({
+      id: "job-001",
+      recruiterId: RECRUITER_ID,
+    });
+
+    const { POST } = await import("@/app/api/recruiter/watches/route");
+    await POST(createPostRequest({ ...validBody, jobId: "job-001" }));
+
+    expect(mockPrisma.jobPosting.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: "job-001",
+        recruiterId: RECRUITER_ID,
+      },
+    });
+  });
+
+  it("存在しないjobIdで404を返す", async () => {
+    mockPrisma.jobPosting.findFirst.mockResolvedValue(null);
+
+    const { POST } = await import("@/app/api/recruiter/watches/route");
+    const response = await POST(
+      createPostRequest({ ...validBody, jobId: "nonexistent-job" }),
+    );
+
+    expect(response.status).toBe(404);
+    expect(mockPrisma.candidateWatch.create).not.toHaveBeenCalled();
+  });
+
+  it("他のリクルーターの求人IDで404を返す", async () => {
+    mockPrisma.jobPosting.findFirst.mockResolvedValue(null); // recruiterId不一致
+
+    const { POST } = await import("@/app/api/recruiter/watches/route");
+    const response = await POST(
+      createPostRequest({ ...validBody, jobId: "other-recruiter-job" }),
+    );
+
+    expect(response.status).toBe(404);
+    expect(mockPrisma.candidateWatch.create).not.toHaveBeenCalled();
+  });
+
+  it("jobIdなしの場合は求人チェックをスキップする", async () => {
+    const { POST } = await import("@/app/api/recruiter/watches/route");
+    await POST(createPostRequest(validBody));
+
+    expect(mockPrisma.jobPosting.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("job情報をincludeして返す", async () => {
+    const { POST } = await import("@/app/api/recruiter/watches/route");
+    await POST(createPostRequest(validBody));
+
+    expect(mockPrisma.candidateWatch.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        include: {
+          job: {
+            select: { id: true, title: true },
+          },
+        },
+      }),
+    );
+  });
+
+  // ── バックグラウンドマッチング ──────────────────────────────────
+
+  it("作成後に既存エージェントとのマッチングを実行する", async () => {
+    const { POST } = await import("@/app/api/recruiter/watches/route");
+    await POST(createPostRequest(validBody));
+
+    // checkExistingAgentsForWatch がwatchIdで呼ばれたことを確認
+    expect(mockPrisma.candidateWatch.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: mockWatchCreated.id },
+      }),
+    );
+  });
+
+  it("マッチング処理が失敗してもウォッチ作成は成功する", async () => {
+    mockPrisma.candidateWatch.findUnique.mockRejectedValue(
+      new Error("マッチング処理エラー"),
+    );
+
+    const { POST } = await import("@/app/api/recruiter/watches/route");
+    const response = await POST(createPostRequest(validBody));
+
+    expect(response.status).toBe(201);
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      "ウォッチ作成後のマッチング処理に失敗しました",
+      expect.any(Error),
+      expect.objectContaining({ watchId: mockWatchCreated.id }),
+    );
+  });
+
+  it("マッチするエージェントがいた場合通知を作成する", async () => {
+    // マッチスコア0.5以上になるエージェントをセットアップ
+    mockPrisma.candidateWatch.findUnique.mockResolvedValue({
+      id: mockWatchCreated.id,
+      skills: ["React"],
+      keywords: [],
+      experienceLevel: null,
+      isActive: true,
+      recruiter: { companyId: COMPANY_ID },
+    });
+    mockPrisma.agentProfile.findMany.mockResolvedValue([
+      {
+        id: "agent-001",
+        user: {
+          fragments: [{ skills: ["React", "TypeScript"], keywords: [] }],
+        },
+      },
+    ]);
+    mockPrisma.watchNotification.upsert.mockResolvedValue({});
+
+    const { POST } = await import("@/app/api/recruiter/watches/route");
+    await POST(
+      createPostRequest({ name: "スキルウォッチ", skills: ["React"] }),
+    );
+
+    expect(mockPrisma.watchNotification.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          watchId_agentId: {
+            watchId: mockWatchCreated.id,
+            agentId: "agent-001",
+          },
+        },
+        create: expect.objectContaining({
+          watchId: mockWatchCreated.id,
+          agentId: "agent-001",
+        }),
+      }),
+    );
+  });
+
+  it("非アクティブなウォッチではマッチングをスキップする", async () => {
+    mockPrisma.candidateWatch.findUnique.mockResolvedValue({
+      ...mockWatchCreated,
+      isActive: false,
+      recruiter: { companyId: COMPANY_ID },
+    });
+
+    const { POST } = await import("@/app/api/recruiter/watches/route");
+    await POST(createPostRequest(validBody));
+
+    expect(mockPrisma.agentProfile.findMany).not.toHaveBeenCalled();
+  });
+
+  // ── バリデーション ────────────────────────────────────────────────
+
+  it("名前なしで400を返す", async () => {
+    const { POST } = await import("@/app/api/recruiter/watches/route");
+    const response = await POST(createPostRequest({}));
+
+    expect(response.status).toBe(400);
+    expect(mockPrisma.candidateWatch.create).not.toHaveBeenCalled();
+  });
+
+  it("空の名前で400を返す", async () => {
+    const { POST } = await import("@/app/api/recruiter/watches/route");
+    const response = await POST(createPostRequest({ name: "" }));
+
+    expect(response.status).toBe(400);
+  });
+
+  it("名前が200文字を超えると400を返す", async () => {
+    const { POST } = await import("@/app/api/recruiter/watches/route");
+    const response = await POST(createPostRequest({ name: "a".repeat(201) }));
+
+    expect(response.status).toBe(400);
+  });
+
+  it("無効なexperienceLevelで400を返す", async () => {
+    const { POST } = await import("@/app/api/recruiter/watches/route");
+    const response = await POST(
+      createPostRequest({ ...validBody, experienceLevel: "INVALID" }),
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("全ての有効なexperienceLevelを受け入れる", async () => {
+    const levels = ["JUNIOR", "MID", "SENIOR", "LEAD"];
+
+    const { POST } = await import("@/app/api/recruiter/watches/route");
+
+    for (const experienceLevel of levels) {
+      vi.clearAllMocks();
+      mockGetServerSession.mockResolvedValue(recruiterSession);
+      mockPrisma.candidateWatch.create.mockResolvedValue(mockWatchCreated);
+      mockPrisma.candidateWatch.findUnique.mockResolvedValue({
+        ...mockWatchCreated,
+        isActive: true,
+        recruiter: { companyId: COMPANY_ID },
+      });
+      mockPrisma.agentProfile.findMany.mockResolvedValue([]);
+
+      const response = await POST(
+        createPostRequest({ ...validBody, experienceLevel }),
+      );
+      expect(response.status).toBe(201);
+    }
+  });
+
+  it("skillsが50個を超えると400を返す", async () => {
+    const { POST } = await import("@/app/api/recruiter/watches/route");
+    const response = await POST(
+      createPostRequest({
+        ...validBody,
+        skills: Array.from({ length: 51 }, (_, i) => `skill-${i}`),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  // ── 認証 ──────────────────────────────────────────────────────────
+
+  it("未認証の場合401を返す", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const { POST } = await import("@/app/api/recruiter/watches/route");
+    const response = await POST(createPostRequest(validBody));
+
+    expect(response.status).toBe(401);
+  });
+
+  it("recruiterIdがない場合403を返す", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { accountId: ACCOUNT_ID, companyId: COMPANY_ID },
+    });
+
+    const { POST } = await import("@/app/api/recruiter/watches/route");
+    const response = await POST(createPostRequest(validBody));
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/src/app/api/subscription/change/route.ts
+++ b/src/app/api/subscription/change/route.ts
@@ -1,10 +1,6 @@
-import { type PlanType, PointTransactionType } from "@prisma/client";
-import { NextResponse } from "next/server";
 import { z } from "zod";
 import { withRecruiterValidation } from "@/lib/api-utils";
 import { ForbiddenError } from "@/lib/errors";
-import { prisma } from "@/lib/prisma";
-import { PLANS } from "@/lib/stripe";
 
 const changePlanSchema = z.object({
   planType: z.enum(["LIGHT", "STANDARD", "ENTERPRISE"], {
@@ -26,63 +22,10 @@ export const POST = withRecruiterValidation(
       throw new ForbiddenError("プラン変更の権限がありません");
     }
 
-    const { planType } = body;
-    const companyId = session.user.companyId;
-    const planInfo = PLANS[planType as keyof typeof PLANS];
-
-    // 既存のサブスクリプションを確認
-    const existingSubscription = await prisma.subscription.findUnique({
-      where: { companyId },
-    });
-
-    if (existingSubscription) {
-      // プラン変更
-      const updatedSubscription = await prisma.subscription.update({
-        where: { companyId },
-        data: {
-          planType: planType as PlanType,
-          pointsIncluded: planInfo.pointsIncluded,
-        },
-      });
-
-      return NextResponse.json({
-        subscription: updatedSubscription,
-        message: "プランを変更しました",
-      });
-    }
-
-    // 新規サブスクリプション作成
-    const newSubscription = await prisma.$transaction(async (tx) => {
-      const subscription = await tx.subscription.create({
-        data: {
-          companyId,
-          planType: planType as PlanType,
-          pointBalance: planInfo.pointsIncluded,
-          pointsIncluded: planInfo.pointsIncluded,
-          status: "ACTIVE",
-        },
-      });
-
-      // 初回ポイント付与の履歴を記録
-      const expiresAt = new Date();
-      expiresAt.setMonth(expiresAt.getMonth() + 3);
-      await tx.pointTransaction.create({
-        data: {
-          companyId,
-          type: PointTransactionType.GRANT,
-          amount: planInfo.pointsIncluded,
-          balance: planInfo.pointsIncluded,
-          description: `${planInfo.name}プラン開始 - 初回ポイント付与`,
-          expiresAt,
-        },
-      });
-
-      return subscription;
-    });
-
-    return NextResponse.json({
-      subscription: newSubscription,
-      message: "プランを選択しました",
-    });
+    // TODO: Stripe Checkout Session を作成し、決済完了後にwebhookでサブスクリプションを作成・変更する
+    // 現在はStripe連携が未実装のため、直接のプラン変更を無効化
+    throw new ForbiddenError(
+      "プラン変更は現在準備中です。Stripe決済連携の実装後に利用可能になります。",
+    );
   },
 );

--- a/src/app/api/subscription/history/route.ts
+++ b/src/app/api/subscription/history/route.ts
@@ -10,8 +10,13 @@ export const GET = withRecruiterAuth(async (req, session) => {
   }
 
   const searchParams = req.nextUrl.searchParams;
-  const limit = Number.parseInt(searchParams.get("limit") || "50", 10);
-  const offset = Number.parseInt(searchParams.get("offset") || "0", 10);
+  const rawLimit = Number.parseInt(searchParams.get("limit") || "50", 10);
+  const limit = Math.min(
+    Math.max(Number.isNaN(rawLimit) ? 50 : rawLimit, 1),
+    200,
+  );
+  const rawOffset = Number.parseInt(searchParams.get("offset") || "0", 10);
+  const offset = Math.max(Number.isNaN(rawOffset) ? 0 : rawOffset, 0);
 
   const history = await getPointHistory(session.user.companyId, limit, offset);
 

--- a/src/app/api/subscription/points/route.ts
+++ b/src/app/api/subscription/points/route.ts
@@ -1,10 +1,6 @@
-import { PointTransactionType } from "@prisma/client";
-import { NextResponse } from "next/server";
 import { z } from "zod";
 import { withRecruiterValidation } from "@/lib/api-utils";
-import { ForbiddenError, NoSubscriptionError } from "@/lib/errors";
-import { prisma } from "@/lib/prisma";
-import { PLANS } from "@/lib/stripe";
+import { ForbiddenError } from "@/lib/errors";
 
 const purchasePointsSchema = z.object({
   amount: z
@@ -15,7 +11,7 @@ const purchasePointsSchema = z.object({
 
 export const POST = withRecruiterValidation(
   purchasePointsSchema,
-  async (body, req, session) => {
+  async (_body, _req, session) => {
     if (!session.user.companyId) {
       throw new ForbiddenError("会社に所属していません");
     }
@@ -27,55 +23,10 @@ export const POST = withRecruiterValidation(
       throw new ForbiddenError("ポイント購入の権限がありません");
     }
 
-    const { amount } = body;
-    const companyId = session.user.companyId;
-
-    // サブスクリプションを確認
-    const subscription = await prisma.subscription.findUnique({
-      where: { companyId },
-    });
-
-    if (!subscription) {
-      throw new NoSubscriptionError(
-        "サブスクリプションがありません。先にプランを選択してください。",
-      );
-    }
-
-    const planInfo = PLANS[subscription.planType as keyof typeof PLANS];
-    const totalPrice = amount * planInfo.additionalPointPrice;
-
-    // トランザクションでポイント追加
-    const result = await prisma.$transaction(async (tx) => {
-      const newBalance = subscription.pointBalance + amount;
-
-      // サブスクリプションの残高を更新
-      const updatedSubscription = await tx.subscription.update({
-        where: { companyId },
-        data: { pointBalance: newBalance },
-      });
-
-      // 取引履歴を記録
-      const expiresAt = new Date();
-      expiresAt.setMonth(expiresAt.getMonth() + 3);
-      await tx.pointTransaction.create({
-        data: {
-          companyId,
-          type: PointTransactionType.PURCHASE,
-          amount,
-          balance: newBalance,
-          description: `${amount}ポイント追加購入 (¥${totalPrice.toLocaleString()})`,
-          expiresAt,
-        },
-      });
-
-      return { newBalance, updatedSubscription };
-    });
-
-    return NextResponse.json({
-      success: true,
-      newBalance: result.newBalance,
-      purchased: amount,
-      price: totalPrice,
-    });
+    // TODO: Stripe Checkout Session を作成し、決済完了後にwebhookでポイントを付与する
+    // 現在はStripe連携が未実装のため、直接のポイント追加を無効化
+    throw new ForbiddenError(
+      "ポイント購入は現在準備中です。Stripe決済連携の実装後に利用可能になります。",
+    );
   },
 );

--- a/src/app/api/webhooks/stripe/__tests__/stripe-webhook.test.ts
+++ b/src/app/api/webhooks/stripe/__tests__/stripe-webhook.test.ts
@@ -13,11 +13,15 @@ const mockStripe = vi.hoisted(() => ({
   },
 }));
 
+const mockLogger = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
 vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
 vi.mock("@/lib/stripe", () => ({ stripe: mockStripe }));
-vi.mock("@/lib/logger", () => ({
-  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-}));
+vi.mock("@/lib/logger", () => ({ logger: mockLogger }));
 
 import { POST } from "../route";
 
@@ -35,129 +39,328 @@ describe("Stripe Webhook", () => {
     process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
   });
 
-  it("署名なしの場合、400を返す", async () => {
-    const req = createRequest("{}", null);
-    const res = await POST(req);
+  describe("署名検証", () => {
+    it("署名なしの場合、400を返す", async () => {
+      const req = createRequest("{}", null);
+      const res = await POST(req);
 
-    expect(res.status).toBe(400);
-    const json = await res.json();
-    expect(json.error).toBe("Missing signature");
-  });
-
-  it("無効な署名の場合、400を返す", async () => {
-    mockStripe.webhooks.constructEvent.mockImplementation(() => {
-      throw new Error("Invalid signature");
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toBe("Missing signature");
     });
 
-    const req = createRequest("{}", "invalid-sig");
-    const res = await POST(req);
+    it("無効な署名の場合、400を返す", async () => {
+      mockStripe.webhooks.constructEvent.mockImplementation(() => {
+        throw new Error("Invalid signature");
+      });
 
-    expect(res.status).toBe(400);
-    const json = await res.json();
-    expect(json.error).toBe("Invalid signature");
+      const req = createRequest("{}", "invalid-sig");
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toBe("Invalid signature");
+    });
+
+    it("STRIPE_WEBHOOK_SECRETが未設定の場合、500を返す", async () => {
+      delete process.env.STRIPE_WEBHOOK_SECRET;
+
+      const req = createRequest("{}", "valid-sig");
+      const res = await POST(req);
+
+      expect(res.status).toBe(500);
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "STRIPE_WEBHOOK_SECRET is not configured",
+        expect.any(Error),
+      );
+    });
   });
 
-  it("invoice.payment_failed → PAST_DUEに設定", async () => {
-    mockStripe.webhooks.constructEvent.mockReturnValue({
-      type: "invoice.payment_failed",
-      data: {
-        object: {
-          parent: {
-            subscription_details: { subscription: "sub_123" },
+  describe("invoice.payment_failed", () => {
+    it("PAST_DUEに設定する", async () => {
+      mockStripe.webhooks.constructEvent.mockReturnValue({
+        id: "evt_001",
+        type: "invoice.payment_failed",
+        data: {
+          object: {
+            parent: {
+              subscription_details: { subscription: "sub_123" },
+            },
           },
         },
-      },
-    });
-    mockPrisma.subscription.findFirst.mockResolvedValue({
-      id: "local-sub-1",
-      stripeSubscriptionId: "sub_123",
-      status: "ACTIVE",
-    });
-    mockPrisma.subscription.update.mockResolvedValue({
-      id: "local-sub-1",
-      status: "PAST_DUE",
+      });
+      mockPrisma.subscription.findFirst.mockResolvedValue({
+        id: "local-sub-1",
+        stripeSubscriptionId: "sub_123",
+        status: "ACTIVE",
+      });
+      mockPrisma.subscription.update.mockResolvedValue({
+        id: "local-sub-1",
+        status: "PAST_DUE",
+      });
+
+      const req = createRequest("{}", "valid-sig");
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      expect(mockPrisma.subscription.update).toHaveBeenCalledWith({
+        where: { id: "local-sub-1" },
+        data: { status: "PAST_DUE" },
+      });
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        "Subscription marked as PAST_DUE",
+        expect.objectContaining({
+          stripeSubscriptionId: "sub_123",
+          eventId: "evt_001",
+        }),
+      );
     });
 
-    const req = createRequest("{}", "valid-sig");
-    const res = await POST(req);
+    it("subscriptionIDが取得できない場合は警告ログを出す", async () => {
+      mockStripe.webhooks.constructEvent.mockReturnValue({
+        id: "evt_002",
+        type: "invoice.payment_failed",
+        data: {
+          object: { parent: null },
+        },
+      });
 
-    expect(res.status).toBe(200);
-    expect(mockPrisma.subscription.update).toHaveBeenCalledWith({
-      where: { id: "local-sub-1" },
-      data: { status: "PAST_DUE" },
+      const req = createRequest("{}", "valid-sig");
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      expect(mockPrisma.subscription.findFirst).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        "Stripe webhook: no subscription ID in invoice",
+        expect.objectContaining({
+          eventId: "evt_002",
+          eventType: "invoice.payment_failed",
+        }),
+      );
     });
   });
 
-  it("invoice.paid → ACTIVEに復帰", async () => {
-    mockStripe.webhooks.constructEvent.mockReturnValue({
-      type: "invoice.paid",
-      data: {
-        object: {
-          parent: {
-            subscription_details: { subscription: "sub_123" },
+  describe("invoice.paid", () => {
+    it("ACTIVEに復帰する", async () => {
+      mockStripe.webhooks.constructEvent.mockReturnValue({
+        id: "evt_003",
+        type: "invoice.paid",
+        data: {
+          object: {
+            parent: {
+              subscription_details: { subscription: "sub_123" },
+            },
           },
         },
-      },
-    });
-    mockPrisma.subscription.findFirst.mockResolvedValue({
-      id: "local-sub-1",
-      stripeSubscriptionId: "sub_123",
-      status: "PAST_DUE",
-    });
-    mockPrisma.subscription.update.mockResolvedValue({
-      id: "local-sub-1",
-      status: "ACTIVE",
+      });
+      mockPrisma.subscription.findFirst.mockResolvedValue({
+        id: "local-sub-1",
+        stripeSubscriptionId: "sub_123",
+        status: "PAST_DUE",
+      });
+      mockPrisma.subscription.update.mockResolvedValue({
+        id: "local-sub-1",
+        status: "ACTIVE",
+      });
+
+      const req = createRequest("{}", "valid-sig");
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      expect(mockPrisma.subscription.update).toHaveBeenCalledWith({
+        where: { id: "local-sub-1" },
+        data: { status: "ACTIVE" },
+      });
     });
 
-    const req = createRequest("{}", "valid-sig");
-    const res = await POST(req);
+    it("subscriptionIDが取得できない場合は警告ログを出す", async () => {
+      mockStripe.webhooks.constructEvent.mockReturnValue({
+        id: "evt_004",
+        type: "invoice.paid",
+        data: {
+          object: { parent: { subscription_details: {} } },
+        },
+      });
 
-    expect(res.status).toBe(200);
-    expect(mockPrisma.subscription.update).toHaveBeenCalledWith({
-      where: { id: "local-sub-1" },
-      data: { status: "ACTIVE" },
+      const req = createRequest("{}", "valid-sig");
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      expect(mockPrisma.subscription.findFirst).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        "Stripe webhook: no subscription ID in invoice",
+        expect.objectContaining({ eventType: "invoice.paid" }),
+      );
     });
   });
 
-  it("customer.subscription.deleted → CANCELEDに設定", async () => {
-    mockStripe.webhooks.constructEvent.mockReturnValue({
-      type: "customer.subscription.deleted",
-      data: {
-        object: { id: "sub_123" },
-      },
-    });
-    mockPrisma.subscription.findFirst.mockResolvedValue({
-      id: "local-sub-1",
-      stripeSubscriptionId: "sub_123",
-      status: "ACTIVE",
-    });
-    mockPrisma.subscription.update.mockResolvedValue({
-      id: "local-sub-1",
-      status: "CANCELED",
-    });
+  describe("customer.subscription.deleted", () => {
+    it("CANCELEDに設定する", async () => {
+      mockStripe.webhooks.constructEvent.mockReturnValue({
+        id: "evt_005",
+        type: "customer.subscription.deleted",
+        data: {
+          object: { id: "sub_123" },
+        },
+      });
+      mockPrisma.subscription.findFirst.mockResolvedValue({
+        id: "local-sub-1",
+        stripeSubscriptionId: "sub_123",
+        status: "ACTIVE",
+      });
+      mockPrisma.subscription.update.mockResolvedValue({
+        id: "local-sub-1",
+        status: "CANCELED",
+      });
 
-    const req = createRequest("{}", "valid-sig");
-    const res = await POST(req);
+      const req = createRequest("{}", "valid-sig");
+      const res = await POST(req);
 
-    expect(res.status).toBe(200);
-    expect(mockPrisma.subscription.update).toHaveBeenCalledWith({
-      where: { id: "local-sub-1" },
-      data: { status: "CANCELED" },
+      expect(res.status).toBe(200);
+      expect(mockPrisma.subscription.update).toHaveBeenCalledWith({
+        where: { id: "local-sub-1" },
+        data: { status: "CANCELED" },
+      });
     });
   });
 
-  it("不明なイベント → 200 (received: true)", async () => {
-    mockStripe.webhooks.constructEvent.mockReturnValue({
-      type: "unknown.event",
-      data: { object: {} },
+  describe("不明なイベント", () => {
+    it("200 (received: true) を返す", async () => {
+      mockStripe.webhooks.constructEvent.mockReturnValue({
+        id: "evt_006",
+        type: "unknown.event",
+        data: { object: {} },
+      });
+
+      const req = createRequest("{}", "valid-sig");
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.received).toBe(true);
+      expect(mockPrisma.subscription.findFirst).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("エラーハンドリング", () => {
+    it("DB障害時は500を返してStripeにリトライさせる", async () => {
+      mockStripe.webhooks.constructEvent.mockReturnValue({
+        id: "evt_007",
+        type: "invoice.paid",
+        data: {
+          object: {
+            parent: {
+              subscription_details: { subscription: "sub_123" },
+            },
+          },
+        },
+      });
+      mockPrisma.subscription.findFirst.mockRejectedValue(
+        new Error("DB connection failed"),
+      );
+
+      const req = createRequest("{}", "valid-sig");
+      const res = await POST(req);
+
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error).toBe("Webhook processing failed");
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "Stripe webhook event processing failed",
+        expect.any(Error),
+        expect.objectContaining({
+          eventId: "evt_007",
+          eventType: "invoice.paid",
+        }),
+      );
     });
 
-    const req = createRequest("{}", "valid-sig");
-    const res = await POST(req);
+    it("subscription.update障害時も500を返す", async () => {
+      mockStripe.webhooks.constructEvent.mockReturnValue({
+        id: "evt_008",
+        type: "customer.subscription.deleted",
+        data: {
+          object: { id: "sub_123" },
+        },
+      });
+      mockPrisma.subscription.findFirst.mockResolvedValue({
+        id: "local-sub-1",
+        stripeSubscriptionId: "sub_123",
+      });
+      mockPrisma.subscription.update.mockRejectedValue(
+        new Error("Update failed"),
+      );
 
-    expect(res.status).toBe(200);
-    const json = await res.json();
-    expect(json.received).toBe(true);
-    expect(mockPrisma.subscription.findFirst).not.toHaveBeenCalled();
+      const req = createRequest("{}", "valid-sig");
+      const res = await POST(req);
+
+      expect(res.status).toBe(500);
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "Stripe webhook event processing failed",
+        expect.any(Error),
+        expect.objectContaining({
+          eventId: "evt_008",
+          eventType: "customer.subscription.deleted",
+        }),
+      );
+    });
+
+    it("サブスクリプションが見つからない場合は警告ログを出して200を返す", async () => {
+      mockStripe.webhooks.constructEvent.mockReturnValue({
+        id: "evt_009",
+        type: "invoice.paid",
+        data: {
+          object: {
+            parent: {
+              subscription_details: { subscription: "sub_unknown" },
+            },
+          },
+        },
+      });
+      mockPrisma.subscription.findFirst.mockResolvedValue(null);
+
+      const req = createRequest("{}", "valid-sig");
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      expect(mockPrisma.subscription.update).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        "Stripe webhook: subscription not found",
+        expect.objectContaining({ stripeSubscriptionId: "sub_unknown" }),
+      );
+    });
+
+    it("subscription objectのidがオブジェクトの場合も処理できる", async () => {
+      mockStripe.webhooks.constructEvent.mockReturnValue({
+        id: "evt_010",
+        type: "invoice.paid",
+        data: {
+          object: {
+            parent: {
+              subscription_details: {
+                subscription: { id: "sub_from_obj" },
+              },
+            },
+          },
+        },
+      });
+      mockPrisma.subscription.findFirst.mockResolvedValue({
+        id: "local-sub-1",
+        stripeSubscriptionId: "sub_from_obj",
+      });
+      mockPrisma.subscription.update.mockResolvedValue({
+        id: "local-sub-1",
+        status: "ACTIVE",
+      });
+
+      const req = createRequest("{}", "valid-sig");
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      expect(mockPrisma.subscription.update).toHaveBeenCalledWith({
+        where: { id: "local-sub-1" },
+        data: { status: "ACTIVE" },
+      });
+    });
   });
 });

--- a/src/app/api/webhooks/stripe/__tests__/stripe-webhook.test.ts
+++ b/src/app/api/webhooks/stripe/__tests__/stripe-webhook.test.ts
@@ -32,6 +32,7 @@ function createRequest(body: string, signature: string | null) {
 describe("Stripe Webhook", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
   });
 
   it("署名なしの場合、400を返す", async () => {
@@ -60,7 +61,11 @@ describe("Stripe Webhook", () => {
     mockStripe.webhooks.constructEvent.mockReturnValue({
       type: "invoice.payment_failed",
       data: {
-        object: { subscription: "sub_123" },
+        object: {
+          parent: {
+            subscription_details: { subscription: "sub_123" },
+          },
+        },
       },
     });
     mockPrisma.subscription.findFirst.mockResolvedValue({
@@ -87,7 +92,11 @@ describe("Stripe Webhook", () => {
     mockStripe.webhooks.constructEvent.mockReturnValue({
       type: "invoice.paid",
       data: {
-        object: { subscription: "sub_123" },
+        object: {
+          parent: {
+            subscription_details: { subscription: "sub_123" },
+          },
+        },
       },
     });
     mockPrisma.subscription.findFirst.mockResolvedValue({

--- a/src/app/my/agent/page.tsx
+++ b/src/app/my/agent/page.tsx
@@ -315,7 +315,7 @@ export default function AgentPage() {
 
         {/* 右: システムプロンプト — 左パネルの高さに揃えてスクロール */}
         <div
-          className="flex flex-col p-6 rounded-xl border bg-card gap-4 min-h-0 overflow-hidden"
+          className="flex flex-col p-6 rounded-xl border bg-card gap-4 min-h-0"
           style={cardPanelHeight ? { height: cardPanelHeight } : undefined}
         >
           <SystemPromptEditor

--- a/src/app/my/agent/page.tsx
+++ b/src/app/my/agent/page.tsx
@@ -52,6 +52,9 @@ export default function AgentPage() {
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
   const [userName, setUserName] = useState<string>("");
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
+  const [savedSystemPrompt, setSavedSystemPrompt] = useState<string | null>(
+    null,
+  );
   const [isDragging, setIsDragging] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
   const [cardPanelHeight, setCardPanelHeight] = useState<number | undefined>(
@@ -69,6 +72,7 @@ export default function AgentPage() {
       if (response.ok) {
         const data = await response.json();
         setAgent(data.agent);
+        setSavedSystemPrompt(data.agent?.systemPrompt ?? null);
         setFragments(data.fragments || []);
       }
     } catch (error) {
@@ -116,6 +120,7 @@ export default function AgentPage() {
       if (response.ok) {
         const data = await response.json();
         setAgent(data.agent);
+        setSavedSystemPrompt(data.agent.systemPrompt);
       }
     } catch (error) {
       console.error("Failed to generate prompt:", error);
@@ -139,6 +144,7 @@ export default function AgentPage() {
       if (response.ok) {
         const data = await response.json();
         setAgent(data.agent);
+        setSavedSystemPrompt(data.agent.systemPrompt);
       }
     } catch (error) {
       console.error("Failed to update status:", error);
@@ -160,6 +166,7 @@ export default function AgentPage() {
       if (response.ok) {
         const data = await response.json();
         setAgent(data.agent);
+        setSavedSystemPrompt(data.agent.systemPrompt);
       }
     } catch (error) {
       console.error("Failed to update prompt:", error);
@@ -315,11 +322,13 @@ export default function AgentPage() {
 
         {/* 右: システムプロンプト — 左パネルの高さに揃えてスクロール */}
         <div
-          className="flex flex-col p-6 rounded-xl border bg-card gap-4 min-h-0"
+          className="relative flex flex-col p-6 rounded-xl border bg-card gap-4 min-h-0 overflow-hidden"
           style={cardPanelHeight ? { height: cardPanelHeight } : undefined}
         >
+          <div className="absolute top-0 left-0 right-0 h-[2px] bg-gradient-to-r from-primary/60 via-primary to-primary/60" />
           <SystemPromptEditor
             prompt={agent ? agent.systemPrompt : null}
+            savedPrompt={savedSystemPrompt}
             onChange={(value) =>
               agent && setAgent({ ...agent, systemPrompt: value })
             }

--- a/src/app/my/chat/page.tsx
+++ b/src/app/my/chat/page.tsx
@@ -19,10 +19,17 @@ import {
 } from "@/components/ui/card";
 import type { ChatCoverageState } from "@/types";
 
+interface ExtractedFragmentInfo {
+  type: string;
+  content: string;
+  skills: string[];
+}
+
 interface Message {
   id: string;
   role: "user" | "assistant";
   content: string;
+  extractedFragments?: ExtractedFragmentInfo[];
 }
 
 interface CorrectFragmentInfo {
@@ -319,6 +326,19 @@ function ChatPageInner() {
             const meta = JSON.parse(data);
             if (meta.fragmentsExtracted) {
               setFragmentCount((prev) => prev + meta.fragmentsExtracted);
+            }
+            if (meta.fragments && meta.fragments.length > 0) {
+              setMessages((prev) => {
+                const updated = [...prev];
+                const lastMsg = updated[updated.length - 1];
+                if (lastMsg?.role === "assistant") {
+                  updated[updated.length - 1] = {
+                    ...lastMsg,
+                    extractedFragments: meta.fragments,
+                  };
+                }
+                return updated;
+              });
             }
             if (meta.coverage) {
               setCoverage(meta.coverage);

--- a/src/app/my/dashboard/page.tsx
+++ b/src/app/my/dashboard/page.tsx
@@ -9,7 +9,7 @@ import { cn } from "@/lib/utils";
 
 interface DashboardData {
   agent: {
-    status: "PRIVATE" | "PUBLIC" | "DRAFT";
+    status: "PRIVATE" | "PUBLIC";
     systemPrompt: string;
   } | null;
   fragments: {

--- a/src/app/my/inbox/page.tsx
+++ b/src/app/my/inbox/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { type MouseEvent, useCallback, useEffect, useState } from "react";
 import type { DirectMessage, InboxInterest } from "@/components/inbox";
 import { DirectMessageDialog, InboxInterestCard } from "@/components/inbox";
@@ -54,6 +53,25 @@ export default function InboxPage() {
     null,
   );
   const [declineError, setDeclineError] = useState<string | null>(null);
+  const [isPublishing, setIsPublishing] = useState(false);
+
+  const handlePublish = async () => {
+    setIsPublishing(true);
+    try {
+      const response = await fetch("/api/agents/me", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "PUBLIC" }),
+      });
+      if (response.ok) {
+        setAgentStatus("PUBLIC");
+      }
+    } catch (error) {
+      console.error("Failed to publish agent:", error);
+    } finally {
+      setIsPublishing(false);
+    }
+  };
 
   const fetchData = useCallback(async () => {
     try {
@@ -321,11 +339,14 @@ export default function InboxPage() {
                 <p className="text-xs text-muted-foreground text-center">
                   エージェントを公開すると、企業から興味表明を受け取れます
                 </p>
-                <Link href="/my/agent">
-                  <Button variant="outline" size="sm">
-                    エージェントを公開する
-                  </Button>
-                </Link>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handlePublish}
+                  disabled={isPublishing}
+                >
+                  {isPublishing ? "公開中..." : "エージェントを公開する"}
+                </Button>
               </>
             )}
           </div>

--- a/src/app/recruiter/interview/[id]/page.tsx
+++ b/src/app/recruiter/interview/[id]/page.tsx
@@ -18,6 +18,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { calculateCoverage } from "@/lib/coverage";
+import { getAvatarSrc } from "@/lib/utils";
 import type { ChatCoverageState } from "@/types";
 
 interface FragmentReference {
@@ -489,12 +490,7 @@ export default function InterviewPage({
           <Avatar className="size-10">
             {agentInfo.user.avatarPath && (
               <AvatarImage
-                src={
-                  agentInfo.user.avatarPath.startsWith("http://") ||
-                  agentInfo.user.avatarPath.startsWith("https://")
-                    ? agentInfo.user.avatarPath
-                    : `/api/applicant/avatar/${agentInfo.user.avatarPath}`
-                }
+                src={getAvatarSrc(agentInfo.user.avatarPath)}
                 alt={agentInfo.user.name}
               />
             )}

--- a/src/app/recruiter/interview/[id]/page.tsx
+++ b/src/app/recruiter/interview/[id]/page.tsx
@@ -489,7 +489,12 @@ export default function InterviewPage({
           <Avatar className="size-10">
             {agentInfo.user.avatarPath && (
               <AvatarImage
-                src={`/api/applicant/avatar/${agentInfo.user.avatarPath}`}
+                src={
+                  agentInfo.user.avatarPath.startsWith("http://") ||
+                  agentInfo.user.avatarPath.startsWith("https://")
+                    ? agentInfo.user.avatarPath
+                    : `/api/applicant/avatar/${agentInfo.user.avatarPath}`
+                }
                 alt={agentInfo.user.name}
               />
             )}

--- a/src/components/agent/AgentBusinessCard.tsx
+++ b/src/components/agent/AgentBusinessCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { cn } from "@/lib/utils";
+import { cn, getAvatarSrc } from "@/lib/utils";
 
 interface AgentBusinessCardProps {
   name: string;
@@ -25,7 +25,7 @@ export function AgentBusinessCard({
   const avatarSrc = avatarUrl
     ? avatarUrl
     : avatarPath
-      ? `/api/applicant/avatar/${avatarPath}`
+      ? getAvatarSrc(avatarPath)
       : undefined;
   return (
     <div

--- a/src/components/agent/SystemPromptEditor.tsx
+++ b/src/components/agent/SystemPromptEditor.tsx
@@ -33,7 +33,7 @@ export function SystemPromptEditor({
           <Textarea
             value={prompt}
             onChange={(e) => onChange(e.target.value)}
-            className="flex-1 min-h-0 text-sm resize-none"
+            className="flex-1 min-h-0 text-sm resize-none overflow-y-auto [field-sizing:fixed]"
             placeholder="エージェントのシステムプロンプト..."
           />
           <div className="flex gap-2 shrink-0">

--- a/src/components/agent/SystemPromptEditor.tsx
+++ b/src/components/agent/SystemPromptEditor.tsx
@@ -1,10 +1,13 @@
 "use client";
 
+import { Loader2, RefreshCw, Save, Sparkles } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 
 interface SystemPromptEditorProps {
   prompt: string | null;
+  savedPrompt?: string | null;
   onChange: (value: string) => void;
   onSave: () => void;
   onGenerate: () => void;
@@ -13,31 +16,51 @@ interface SystemPromptEditorProps {
 
 export function SystemPromptEditor({
   prompt,
+  savedPrompt,
   onChange,
   onSave,
   onGenerate,
   isGenerating,
 }: SystemPromptEditorProps) {
+  const hasUnsavedChanges =
+    prompt !== null && savedPrompt !== undefined && prompt !== savedPrompt;
+
   return (
     <>
-      <div className="shrink-0">
-        <p className="text-sm font-semibold tracking-tight">
+      <div className="flex items-center justify-between shrink-0">
+        <p className="text-[10px] tracking-widest text-muted-foreground uppercase">
           システムプロンプト
         </p>
-        <p className="text-xs text-muted-foreground mt-0.5">
-          エージェントの振る舞いを定義します
-        </p>
+        {prompt !== null && (
+          <Badge
+            variant={hasUnsavedChanges ? "secondary" : "outline"}
+            className="text-[10px]"
+          >
+            {hasUnsavedChanges ? "未保存" : "保存済み"}
+          </Badge>
+        )}
       </div>
       {prompt !== null ? (
         <>
-          <Textarea
-            value={prompt}
-            onChange={(e) => onChange(e.target.value)}
-            className="flex-1 min-h-0 text-sm resize-none overflow-y-auto [field-sizing:fixed]"
-            placeholder="エージェントのシステムプロンプト..."
-          />
+          <div className="flex-1 flex flex-col min-h-0 gap-1.5">
+            <Textarea
+              value={prompt}
+              onChange={(e) => onChange(e.target.value)}
+              className="flex-1 min-h-0 text-sm resize-none overflow-y-auto [field-sizing:fixed]"
+              placeholder="エージェントのシステムプロンプト..."
+            />
+            <p className="text-[10px] tabular-nums text-muted-foreground text-right">
+              {prompt.length.toLocaleString()} 文字
+            </p>
+          </div>
           <div className="flex gap-2 shrink-0">
-            <Button variant="outline" size="sm" onClick={onSave}>
+            <Button
+              variant={hasUnsavedChanges ? "default" : "outline"}
+              size="sm"
+              onClick={onSave}
+              disabled={!hasUnsavedChanges}
+            >
+              <Save className="size-3.5" />
               保存
             </Button>
             <Button
@@ -46,33 +69,36 @@ export function SystemPromptEditor({
               onClick={onGenerate}
               disabled={isGenerating}
             >
+              {isGenerating ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <RefreshCw className="size-3.5" />
+              )}
               {isGenerating ? "生成中..." : "再生成"}
             </Button>
           </div>
         </>
       ) : (
-        <div className="flex-1 flex flex-col items-center justify-center space-y-3 min-h-0">
-          <div className="size-10 rounded-lg bg-secondary flex items-center justify-center">
-            <svg
-              className="size-5 text-muted-foreground"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={1.5}
-                d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
-              />
-            </svg>
+        <div className="flex-1 flex flex-col items-center justify-center min-h-0">
+          <div className="flex flex-col items-center gap-3 p-6 rounded-xl bg-secondary/30">
+            <div className="size-10 rounded-lg bg-secondary flex items-center justify-center">
+              <Sparkles className="size-5 text-muted-foreground" />
+            </div>
+            <div className="text-center space-y-1">
+              <p className="text-sm font-medium">エージェント未生成</p>
+              <p className="text-xs text-muted-foreground">
+                AIチャットの情報からエージェントを生成します
+              </p>
+            </div>
+            <Button size="sm" onClick={onGenerate} disabled={isGenerating}>
+              {isGenerating ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <Sparkles className="size-3.5" />
+              )}
+              {isGenerating ? "生成中..." : "エージェントを生成"}
+            </Button>
           </div>
-          <p className="text-sm text-muted-foreground text-center">
-            AIチャットの情報からエージェントを生成します
-          </p>
-          <Button size="sm" onClick={onGenerate} disabled={isGenerating}>
-            {isGenerating ? "生成中..." : "エージェントを生成"}
-          </Button>
         </div>
       )}
     </>

--- a/src/components/agents/AgentsAllView.tsx
+++ b/src/components/agents/AgentsAllView.tsx
@@ -12,7 +12,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { cn } from "@/lib/utils";
+import { cn, getAvatarSrc } from "@/lib/utils";
 
 interface Agent {
   id: string;
@@ -310,7 +310,7 @@ export function AgentsAllView({ onSwitchToWatches }: AgentsAllViewProps) {
                   <Avatar className="size-11 ring-2 ring-border group-hover:ring-primary/20 transition-colors">
                     {agent.user.avatarPath && (
                       <AvatarImage
-                        src={`/api/applicant/avatar/${agent.user.avatarPath}`}
+                        src={getAvatarSrc(agent.user.avatarPath)}
                         alt={agent.user.name}
                       />
                     )}

--- a/src/components/agents/InterestCard.tsx
+++ b/src/components/agents/InterestCard.tsx
@@ -9,7 +9,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { cn } from "@/lib/utils";
+import { cn, getAvatarSrc } from "@/lib/utils";
 
 export interface InterestCardInterest {
   id: string;
@@ -68,7 +68,7 @@ export function InterestCard({
           <Avatar className="size-12">
             {interest.user.avatarPath && (
               <AvatarImage
-                src={`/api/applicant/avatar/${interest.user.avatarPath}`}
+                src={getAvatarSrc(interest.user.avatarPath)}
                 alt={interest.user.name}
               />
             )}

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -178,67 +178,31 @@ export function ChatWindow({
             />
           </div>
           {/* マイクボタン */}
-          {voice.mode === "push-to-talk" ? (
-            <div className="relative">
-              {voice.voiceState === "recording" && (
-                <span className="absolute inset-0 rounded-md animate-ping bg-destructive/30" />
-              )}
-              <Button
-                type="button"
-                size="icon"
-                variant={
-                  voice.voiceState === "recording" ? "destructive" : "outline"
-                }
-                className={cn(
-                  "relative",
-                  voice.voiceState === "recording" &&
-                    "ring-2 ring-destructive/50",
-                )}
-                disabled={isVoiceBusy}
-                onPointerDown={voice.onPressStart}
-                onPointerUp={voice.onPressEnd}
-                onPointerLeave={
-                  voice.voiceState === "recording"
-                    ? voice.onPressEnd
-                    : undefined
-                }
-                title="押して話す"
-              >
-                <Mic className="size-4" />
-              </Button>
-            </div>
-          ) : voice.isActive ? (
-            <div className="relative">
-              {voice.voiceState === "recording" && (
-                <span className="absolute inset-0 rounded-md animate-ping bg-destructive/30" />
-              )}
-              <Button
-                type="button"
-                size="icon"
-                variant="destructive"
-                className={cn(
-                  "relative",
-                  voice.voiceState === "recording" &&
-                    "ring-2 ring-destructive/50",
-                )}
-                onClick={voice.toggleContinuous}
-                title="音声会話を停止"
-              >
-                <Square className="size-4" />
-              </Button>
-            </div>
-          ) : (
+          <div className="relative">
+            {voice.isActive && voice.voiceState === "recording" && (
+              <span className="absolute inset-0 rounded-md animate-ping bg-destructive/30" />
+            )}
             <Button
               type="button"
               size="icon"
-              variant="outline"
-              onClick={voice.toggleContinuous}
+              variant={voice.isActive ? "destructive" : "outline"}
+              className={cn(
+                "relative",
+                voice.isActive &&
+                  voice.voiceState === "recording" &&
+                  "ring-2 ring-destructive/50",
+              )}
+              onClick={voice.toggleVoice}
               disabled={isVoiceBusy}
-              title="連続会話を開始"
+              title={voice.isActive ? "音声会話を停止" : "音声会話を開始"}
             >
-              <Mic className="size-4" />
+              {voice.isActive ? (
+                <Square className="size-4" />
+              ) : (
+                <Mic className="size-4" />
+              )}
             </Button>
-          )}
+          </div>
           {/* 送信ボタン */}
           <Button
             type="submit"
@@ -250,23 +214,6 @@ export function ChatWindow({
           </Button>
         </div>
         <div className="flex items-center gap-2 mt-2">
-          <button
-            type="button"
-            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-            onClick={() =>
-              voice.setMode(
-                voice.mode === "push-to-talk" ? "continuous" : "push-to-talk",
-              )
-            }
-            disabled={voice.isActive}
-            title={
-              voice.mode === "push-to-talk"
-                ? "連続会話モードに切替"
-                : "Push-to-talkモードに切替"
-            }
-          >
-            {voice.mode === "push-to-talk" ? "PTT" : "連続"}
-          </button>
           <span className="text-xs text-muted-foreground">
             {voice.voiceState === "recording"
               ? formatDuration(voice.duration)

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -15,7 +15,7 @@ import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Textarea } from "@/components/ui/textarea";
 import { useVoiceConversation } from "@/hooks/useVoiceConversation";
-import { cn } from "@/lib/utils";
+import { cn, getAvatarSrc } from "@/lib/utils";
 import { FragmentCard } from "./FragmentCard";
 import { MessageBubble } from "./MessageBubble";
 
@@ -156,12 +156,7 @@ export function ChatWindow({
               <Avatar className="size-7 flex-shrink-0">
                 {assistantAvatarPath && (
                   <AvatarImage
-                    src={
-                      assistantAvatarPath.startsWith("http://") ||
-                      assistantAvatarPath.startsWith("https://")
-                        ? assistantAvatarPath
-                        : `/api/applicant/avatar/${assistantAvatarPath}`
-                    }
+                    src={getAvatarSrc(assistantAvatarPath)}
                     alt={assistantName || "AI"}
                   />
                 )}

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -1,18 +1,31 @@
 "use client";
 
 import { Mic, SendHorizontal, Square } from "lucide-react";
-import type { RefObject } from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Fragment as ReactFragment,
+  type RefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { FollowUpSuggestions } from "@/components/interview/FollowUpSuggestions";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Textarea } from "@/components/ui/textarea";
 import { useVoiceConversation } from "@/hooks/useVoiceConversation";
 import { cn } from "@/lib/utils";
+import { FragmentCard } from "./FragmentCard";
 import { MessageBubble } from "./MessageBubble";
 
 interface FragmentReference {
   id: string;
+  type: string;
+  content: string;
+  skills: string[];
+}
+
+interface ExtractedFragmentInfo {
   type: string;
   content: string;
   skills: string[];
@@ -23,6 +36,7 @@ interface Message {
   role: "user" | "assistant";
   content: string;
   references?: FragmentReference[];
+  extractedFragments?: ExtractedFragmentInfo[];
 }
 
 interface ChatWindowProps {
@@ -119,16 +133,22 @@ export function ChatWindow({
             </div>
           )}
           {messages.map((message) => (
-            <MessageBubble
-              key={message.id}
-              messageId={message.id}
-              content={message.content}
-              role={message.role}
-              senderName={userName}
-              assistantName={assistantName}
-              assistantAvatarPath={assistantAvatarPath}
-              references={message.references}
-            />
+            <ReactFragment key={message.id}>
+              <MessageBubble
+                messageId={message.id}
+                content={message.content}
+                role={message.role}
+                senderName={userName}
+                assistantName={assistantName}
+                assistantAvatarPath={assistantAvatarPath}
+                references={message.references}
+              />
+              {message.role === "assistant" &&
+                message.extractedFragments &&
+                message.extractedFragments.length > 0 && (
+                  <FragmentCard fragments={message.extractedFragments} />
+                )}
+            </ReactFragment>
           ))}
           {isLoading && messages[messages.length - 1]?.role !== "assistant" && (
             <div className="flex gap-2.5">

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -106,7 +106,7 @@ export function ChatWindow({
   );
 
   const isVoiceBusy =
-    voice.voiceState !== "inactive" && voice.voiceState !== "recording";
+    voice.voiceState === "transcribing" || voice.voiceState === "waiting";
 
   return (
     <div className="flex flex-col h-full">

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -10,6 +10,7 @@ import {
   useState,
 } from "react";
 import { FollowUpSuggestions } from "@/components/interview/FollowUpSuggestions";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Textarea } from "@/components/ui/textarea";
@@ -152,11 +153,22 @@ export function ChatWindow({
           ))}
           {isLoading && messages[messages.length - 1]?.role !== "assistant" && (
             <div className="flex gap-2.5">
-              <div className="size-7 rounded-full bg-primary/10 flex items-center justify-center">
-                <span className="text-xs text-primary">
+              <Avatar className="size-7 flex-shrink-0">
+                {assistantAvatarPath && (
+                  <AvatarImage
+                    src={
+                      assistantAvatarPath.startsWith("http://") ||
+                      assistantAvatarPath.startsWith("https://")
+                        ? assistantAvatarPath
+                        : `/api/applicant/avatar/${assistantAvatarPath}`
+                    }
+                    alt={assistantName || "AI"}
+                  />
+                )}
+                <AvatarFallback className="text-xs bg-primary/10 text-primary">
                   {assistantName?.[0] || "AI"}
-                </span>
-              </div>
+                </AvatarFallback>
+              </Avatar>
               <div className="bg-secondary rounded-lg px-3.5 py-2">
                 <div className="flex gap-1">
                   <span className="size-1.5 bg-muted-foreground/60 rounded-full animate-bounce" />

--- a/src/components/chat/FinishSuggestion.tsx
+++ b/src/components/chat/FinishSuggestion.tsx
@@ -51,7 +51,9 @@ export function FinishSuggestion({
                 : "text-blue-800 dark:text-blue-200",
             )}
           >
-            {isComplete ? "情報収集が完了しました" : "そろそろ終わりにできます"}
+            {isComplete
+              ? "あなたのことが分かりました！"
+              : "かなりあなたのことが分かってきました"}
           </p>
           <p
             className={cn(
@@ -62,8 +64,8 @@ export function FinishSuggestion({
             )}
           >
             {isComplete
-              ? "十分な情報が集まりました。エージェントを作成できます。"
-              : `進捗${coverage.percentage}% - もう少し話すとより良いエージェントになります。`}
+              ? "あなたらしいエージェントを作る準備ができました！"
+              : "もう少し話してくれると、さらにあなたらしいエージェントが作れます。"}
           </p>
         </div>
       </div>

--- a/src/components/chat/FragmentCard.tsx
+++ b/src/components/chat/FragmentCard.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Sparkles } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { fragmentTypeLabels } from "@/lib/fragment-utils";
+
+interface ExtractedFragmentInfo {
+  type: string;
+  content: string;
+  skills: string[];
+}
+
+interface FragmentCardProps {
+  fragments: ExtractedFragmentInfo[];
+}
+
+export function FragmentCard({ fragments }: FragmentCardProps) {
+  return (
+    <div className="flex max-w-[80%] animate-in fade-in-0 slide-in-from-bottom-2 duration-300">
+      <div className="rounded-lg border border-amber-300/50 bg-amber-50/50 dark:border-amber-500/30 dark:bg-amber-950/20 px-3.5 py-2.5 space-y-2">
+        <div className="flex items-center gap-1.5 text-amber-700 dark:text-amber-400">
+          <Sparkles className="size-3.5" />
+          <span className="text-xs font-medium">記憶のかけら</span>
+        </div>
+        <div className="space-y-1.5">
+          {fragments.map((fragment, i) => (
+            <div
+              // biome-ignore lint/suspicious/noArrayIndexKey: 抽出結果は並べ替え不要な一時表示
+              key={i}
+              className="text-xs space-y-1"
+            >
+              <div className="flex items-center gap-1 flex-wrap">
+                <Badge variant="outline" className="text-[10px] px-1 py-0">
+                  {fragmentTypeLabels[fragment.type] || fragment.type}
+                </Badge>
+                {fragment.skills.slice(0, 3).map((skill) => (
+                  <Badge
+                    key={skill}
+                    variant="secondary"
+                    className="text-[10px] px-1 py-0"
+                  >
+                    {skill}
+                  </Badge>
+                ))}
+              </div>
+              <p className="text-muted-foreground line-clamp-2">
+                {fragment.content}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -8,6 +8,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
+import { fragmentTypeLabels } from "@/lib/fragment-utils";
 import { cn } from "@/lib/utils";
 
 interface FragmentReference {
@@ -26,17 +27,6 @@ interface MessageBubbleProps {
   references?: FragmentReference[];
   messageId?: string;
 }
-
-const fragmentTypeLabels: Record<string, string> = {
-  ACHIEVEMENT: "実績",
-  ACTION: "行動",
-  CHALLENGE: "課題",
-  LEARNING: "学び",
-  VALUE: "価値観",
-  EMOTION: "感情",
-  FACT: "事実",
-  SKILL_USAGE: "スキル活用",
-};
 
 export function MessageBubble({
   content,

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -9,7 +9,7 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { fragmentTypeLabels } from "@/lib/fragment-utils";
-import { cn } from "@/lib/utils";
+import { cn, getAvatarSrc } from "@/lib/utils";
 
 interface FragmentReference {
   id: string;
@@ -52,12 +52,7 @@ export function MessageBubble({
       <Avatar className="size-7 flex-shrink-0 mt-0.5">
         {!isUser && assistantAvatarPath && (
           <AvatarImage
-            src={
-              assistantAvatarPath.startsWith("http://") ||
-              assistantAvatarPath.startsWith("https://")
-                ? assistantAvatarPath
-                : `/api/applicant/avatar/${assistantAvatarPath}`
-            }
+            src={getAvatarSrc(assistantAvatarPath)}
             alt={assistantName || "AI"}
           />
         )}

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -52,7 +52,12 @@ export function MessageBubble({
       <Avatar className="size-7 flex-shrink-0 mt-0.5">
         {!isUser && assistantAvatarPath && (
           <AvatarImage
-            src={`/api/applicant/avatar/${assistantAvatarPath}`}
+            src={
+              assistantAvatarPath.startsWith("http://") ||
+              assistantAvatarPath.startsWith("https://")
+                ? assistantAvatarPath
+                : `/api/applicant/avatar/${assistantAvatarPath}`
+            }
             alt={assistantName || "AI"}
           />
         )}

--- a/src/components/documents/DocumentListItem.tsx
+++ b/src/components/documents/DocumentListItem.tsx
@@ -1,5 +1,11 @@
-import { FileText, Trash2 } from "lucide-react";
+import { ChevronRight, FileText, Trash2 } from "lucide-react";
+import { FragmentList } from "@/components/agent";
 import { Button } from "@/components/ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
 
 type AnalysisStatus = "PENDING" | "ANALYZING" | "COMPLETED" | "FAILED";
@@ -12,6 +18,16 @@ export interface DocumentData {
   analysisError: string | null;
   analyzedAt: string | null;
   createdAt: string;
+  fragmentCount: number;
+}
+
+export interface FragmentData {
+  id: string;
+  type: string;
+  content: string;
+  skills: string[];
+  keywords: string[];
+  createdAt: string;
 }
 
 export interface DocumentListItemProps {
@@ -19,6 +35,10 @@ export interface DocumentListItemProps {
   isLast: boolean;
   onAnalyze: (id: string) => void;
   onDelete: (document: DocumentData) => void;
+  isExpanded: boolean;
+  fragments: FragmentData[];
+  isLoadingFragments: boolean;
+  onToggleFragments: (id: string) => void;
 }
 
 function StatusBadge({
@@ -76,7 +96,14 @@ export function DocumentListItem({
   isLast,
   onAnalyze,
   onDelete,
+  isExpanded,
+  fragments,
+  isLoadingFragments,
+  onToggleFragments,
 }: DocumentListItemProps) {
+  const hasFragments =
+    document.analysisStatus === "COMPLETED" && document.fragmentCount > 0;
+
   return (
     <div
       className={cn(
@@ -123,6 +150,33 @@ export function DocumentListItem({
           )}
         </div>
       </div>
+
+      {hasFragments && (
+        <Collapsible
+          open={isExpanded}
+          onOpenChange={() => onToggleFragments(document.id)}
+          className="mt-3"
+        >
+          <CollapsibleTrigger className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors">
+            <ChevronRight
+              className={cn(
+                "size-3.5 transition-transform",
+                isExpanded && "rotate-90",
+              )}
+            />
+            <span>記憶のかけら ({document.fragmentCount}件)</span>
+          </CollapsibleTrigger>
+          <CollapsibleContent className="mt-2 ml-1">
+            {isLoadingFragments ? (
+              <div className="flex items-center justify-center py-4">
+                <div className="size-4 border-2 border-primary/20 border-t-primary rounded-full animate-spin" />
+              </div>
+            ) : (
+              <FragmentList fragments={fragments} />
+            )}
+          </CollapsibleContent>
+        </Collapsible>
+      )}
     </div>
   );
 }

--- a/src/components/documents/index.ts
+++ b/src/components/documents/index.ts
@@ -1,6 +1,7 @@
 export type {
   DocumentData,
   DocumentListItemProps,
+  FragmentData,
 } from "./DocumentListItem";
 export { DocumentListItem } from "./DocumentListItem";
 export type { DocumentUploadDialogProps } from "./DocumentUploadDialog";

--- a/src/hooks/__tests__/useVoiceRecording.test.ts
+++ b/src/hooks/__tests__/useVoiceRecording.test.ts
@@ -41,7 +41,7 @@ const mockTrackStop = vi.fn();
 // AudioContext モック
 const mockGetByteTimeDomainData = vi.fn();
 const mockConnect = vi.fn();
-const mockClose = vi.fn();
+const mockClose = vi.fn().mockResolvedValue(undefined);
 
 const mockAnalyser = {
   fftSize: 2048,

--- a/src/hooks/useVoiceConversation.ts
+++ b/src/hooks/useVoiceConversation.ts
@@ -148,14 +148,19 @@ export function useVoiceConversation({
     if (isActive) {
       isActiveRef.current = false;
       setIsActive(false);
-      recordingRef.current
-        ?.stopRecording()
+      const rec = recordingRef.current;
+      if (!rec) {
+        setVoiceState("inactive");
+        return;
+      }
+      rec
+        .stopRecording()
         .then(() => {
-          recordingRef.current?.releaseStream();
+          rec.releaseStream();
           setVoiceState("inactive");
         })
         .catch(() => {
-          recordingRef.current?.releaseStream();
+          rec.releaseStream();
           setVoiceState("inactive");
         });
     } else {
@@ -163,14 +168,21 @@ export function useVoiceConversation({
       isActiveRef.current = true;
       setIsActive(true);
       setVoiceState("recording");
-      recordingRef.current
-        ?.acquireStream()
+      const rec = recordingRef.current;
+      if (!rec) {
+        setIsActive(false);
+        isActiveRef.current = false;
+        setVoiceState("inactive");
+        return;
+      }
+      rec
+        .acquireStream()
         .then(() => {
-          return recordingRef.current?.startRecording();
+          return rec.startRecording();
         })
         .catch(() => {
           setError("録音の開始に失敗しました");
-          recordingRef.current?.releaseStream();
+          rec.releaseStream();
           setIsActive(false);
           isActiveRef.current = false;
           setVoiceState("inactive");

--- a/src/lib/__tests__/matching.test.ts
+++ b/src/lib/__tests__/matching.test.ts
@@ -1,0 +1,397 @@
+/**
+ * マッチングロジック 単体テスト
+ *
+ * エージェント公開時の自動マッチング、求人レコメンド、ウォッチ通知を支える
+ * コアスコアリングロジックをテストする。
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  calculateExperienceMatch,
+  calculateJobMatchScore,
+  calculateKeywordMatch,
+  calculateSkillMatch,
+  calculateWatchMatchScore,
+  extractSkillsAndKeywords,
+} from "../matching";
+
+// ── calculateSkillMatch ──────────────────────────────────
+
+describe("calculateSkillMatch", () => {
+  describe("完全一致", () => {
+    it("全スキルが一致する場合1.0を返す", () => {
+      expect(
+        calculateSkillMatch(["React", "TypeScript"], ["React", "TypeScript"]),
+      ).toBe(1.0);
+    });
+
+    it("大文字小文字を無視して一致する", () => {
+      expect(
+        calculateSkillMatch(["react", "TYPESCRIPT"], ["React", "TypeScript"]),
+      ).toBe(1.0);
+    });
+  });
+
+  describe("部分一致", () => {
+    it("求人スキルが候補スキルの部分文字列の場合に一致する", () => {
+      // "react" は "react.js" に含まれる
+      expect(calculateSkillMatch(["React"], ["React.js"])).toBe(1.0);
+    });
+
+    it("候補スキルが求人スキルの部分文字列の場合に一致する", () => {
+      // "node" は "node.js" に含まれる（逆方向: 求人スキルが候補スキルを含む）
+      expect(calculateSkillMatch(["Node.js"], ["Node"])).toBe(1.0);
+    });
+
+    it("一部のみ一致する場合は比率を返す", () => {
+      const score = calculateSkillMatch(["React", "Vue", "Angular"], ["React"]);
+      expect(score).toBeCloseTo(1 / 3);
+    });
+  });
+
+  describe("不一致", () => {
+    it("一致するスキルがない場合0を返す", () => {
+      expect(
+        calculateSkillMatch(["Python", "Go"], ["React", "TypeScript"]),
+      ).toBe(0);
+    });
+  });
+
+  describe("エッジケース", () => {
+    it("求人スキルが空の場合1.0を返す（スキル要件なし）", () => {
+      expect(calculateSkillMatch([], ["React", "TypeScript"])).toBe(1.0);
+    });
+
+    it("候補スキルが空の場合0を返す", () => {
+      expect(calculateSkillMatch(["React"], [])).toBe(0);
+    });
+
+    it("両方空の場合1.0を返す", () => {
+      expect(calculateSkillMatch([], [])).toBe(1.0);
+    });
+
+    it("重複スキルはSet化により正規化される", () => {
+      const score = calculateSkillMatch(["React", "React", "Vue"], ["React"]);
+      // Set化で ["React", "Vue"] → 1/2 一致
+      expect(score).toBe(0.5);
+    });
+  });
+});
+
+// ── calculateKeywordMatch ──────────────────────────────────
+
+describe("calculateKeywordMatch", () => {
+  it("全キーワードが一致する場合1.0を返す", () => {
+    expect(
+      calculateKeywordMatch(
+        ["フロントエンド", "バックエンド"],
+        ["フロントエンド", "バックエンド"],
+      ),
+    ).toBe(1.0);
+  });
+
+  it("部分一致でマッチする", () => {
+    // "フロント" は "フロントエンド" に含まれる
+    expect(calculateKeywordMatch(["フロント"], ["フロントエンド"])).toBe(1.0);
+  });
+
+  it("一部のみ一致する場合は比率を返す", () => {
+    const score = calculateKeywordMatch(
+      ["機械学習", "データ分析", "NLP"],
+      ["機械学習"],
+    );
+    expect(score).toBeCloseTo(1 / 3);
+  });
+
+  it("求人キーワードが空の場合1.0を返す", () => {
+    expect(calculateKeywordMatch([], ["キーワード"])).toBe(1.0);
+  });
+
+  it("候補キーワードが空の場合0を返す", () => {
+    expect(calculateKeywordMatch(["キーワード"], [])).toBe(0);
+  });
+});
+
+// ── calculateExperienceMatch ──────────────────────────────────
+
+describe("calculateExperienceMatch", () => {
+  // ヘルパー: 指定タイプのフラグメントをN個生成
+  function makeFragments(count: number, type = "FACT"): { type: string }[] {
+    return Array.from({ length: count }, () => ({ type }));
+  }
+
+  describe("経験レベル推定ロジック", () => {
+    it("フラグメント0件 → ENTRY相当（レベル0）", () => {
+      // ENTRY要求 vs レベル0推定 → diff=0 → 1.0
+      expect(calculateExperienceMatch("ENTRY", [])).toBe(1.0);
+    });
+
+    it("フラグメント3件 → JUNIOR相当（レベル1）", () => {
+      expect(calculateExperienceMatch("JUNIOR", makeFragments(3))).toBe(1.0);
+    });
+
+    it("フラグメント6件 → MID相当（レベル2）", () => {
+      expect(calculateExperienceMatch("MID", makeFragments(6))).toBe(1.0);
+    });
+
+    it("フラグメント10件 → SENIOR相当（レベル3）", () => {
+      expect(calculateExperienceMatch("SENIOR", makeFragments(10))).toBe(1.0);
+    });
+
+    it("フラグメント15件以上 → LEAD相当（レベル4）", () => {
+      expect(calculateExperienceMatch("LEAD", makeFragments(15))).toBe(1.0);
+    });
+  });
+
+  describe("レベル差によるスコア減衰", () => {
+    it("差1 → 0.7", () => {
+      // JUNIOR(1)要求 vs 0件→ENTRY(0)推定 → diff=1
+      expect(calculateExperienceMatch("JUNIOR", [])).toBe(0.7);
+    });
+
+    it("差2 → 0.4", () => {
+      // MID(2)要求 vs 0件→ENTRY(0)推定 → diff=2
+      expect(calculateExperienceMatch("MID", [])).toBe(0.4);
+    });
+
+    it("差3以上 → 0.2", () => {
+      // LEAD(4)要求 vs 0件→ENTRY(0)推定 → diff=4
+      expect(calculateExperienceMatch("LEAD", [])).toBe(0.2);
+    });
+  });
+
+  describe("フラグメントタイプフィルタリング", () => {
+    it("FACT, SKILL_USAGE, ACHIEVEMENTのみカウントされる", () => {
+      const fragments = [
+        { type: "FACT" },
+        { type: "SKILL_USAGE" },
+        { type: "ACHIEVEMENT" },
+        { type: "VALUE" }, // カウントされない
+        { type: "EMOTION" }, // カウントされない
+        { type: "LEARNING" }, // カウントされない
+      ];
+      // 有効3件 → JUNIOR(1)推定
+      expect(calculateExperienceMatch("JUNIOR", fragments)).toBe(1.0);
+    });
+
+    it("関連しないフラグメントのみの場合はENTRY扱い", () => {
+      const fragments = [
+        { type: "VALUE" },
+        { type: "EMOTION" },
+        { type: "LEARNING" },
+      ];
+      // 有効0件 → ENTRY(0)推定
+      expect(calculateExperienceMatch("ENTRY", fragments)).toBe(1.0);
+    });
+  });
+
+  describe("不明なレベル値", () => {
+    it("未知の文字列はMID(2)相当にフォールバックする", () => {
+      // 不明なレベル → levelMap[unknown] ?? 2 → MID
+      // 0件→ENTRY(0)推定 vs MID(2) → diff=2 → 0.4
+      expect(calculateExperienceMatch("UNKNOWN", [])).toBe(0.4);
+    });
+  });
+});
+
+// ── calculateJobMatchScore ──────────────────────────────────
+
+describe("calculateJobMatchScore", () => {
+  it("完全一致のスコアを計算する", () => {
+    const result = calculateJobMatchScore(
+      {
+        skills: ["React", "TypeScript"],
+        keywords: ["フロントエンド"],
+        experienceLevel: "MID",
+      },
+      {
+        skills: ["React", "TypeScript"],
+        keywords: ["フロントエンド"],
+        fragments: makeFragments(6),
+      },
+    );
+
+    expect(result.skillScore).toBe(1.0);
+    expect(result.keywordScore).toBe(1.0);
+    expect(result.experienceScore).toBe(1.0);
+    expect(result.totalScore).toBe(1.0);
+  });
+
+  it("デフォルト重みで加重平均を計算する（0.45/0.35/0.2）", () => {
+    const result = calculateJobMatchScore(
+      {
+        skills: ["React", "Vue"], // 50%一致
+        keywords: ["フロントエンド", "バックエンド"], // 50%一致
+        experienceLevel: "MID",
+      },
+      {
+        skills: ["React"],
+        keywords: ["フロントエンド"],
+        fragments: makeFragments(6), // MID → 完全一致
+      },
+    );
+
+    expect(result.skillScore).toBe(0.5);
+    expect(result.keywordScore).toBe(0.5);
+    expect(result.experienceScore).toBe(1.0);
+    // 0.5 * 0.45 + 0.5 * 0.35 + 1.0 * 0.2 = 0.225 + 0.175 + 0.2 = 0.6
+    expect(result.totalScore).toBe(0.6);
+  });
+
+  it("カスタム重みを使用できる", () => {
+    const result = calculateJobMatchScore(
+      {
+        skills: ["React"],
+        keywords: [],
+        experienceLevel: "ENTRY",
+      },
+      {
+        skills: ["React"],
+        keywords: [],
+        fragments: [],
+      },
+      { skill: 1.0, keyword: 0, experience: 0 },
+    );
+
+    expect(result.totalScore).toBe(1.0);
+  });
+
+  it("スコアは小数点以下2桁に丸められる", () => {
+    const result = calculateJobMatchScore(
+      {
+        skills: ["React", "Vue", "Angular"],
+        keywords: [],
+        experienceLevel: "ENTRY",
+      },
+      {
+        skills: ["React"],
+        keywords: [],
+        fragments: [],
+      },
+    );
+
+    // skillScore = 1/3 → 0.33
+    expect(result.skillScore).toBe(0.33);
+  });
+
+  it("完全不一致の場合は低スコアを返す", () => {
+    const result = calculateJobMatchScore(
+      {
+        skills: ["Python", "Go"],
+        keywords: ["機械学習"],
+        experienceLevel: "SENIOR",
+      },
+      {
+        skills: ["React"],
+        keywords: ["フロントエンド"],
+        fragments: [],
+      },
+    );
+
+    expect(result.skillScore).toBe(0);
+    expect(result.keywordScore).toBe(0);
+    // SENIOR(3) vs ENTRY(0) → diff=3 → 0.2
+    expect(result.experienceScore).toBe(0.2);
+    expect(result.totalScore).toBe(0.04); // 0 + 0 + 0.2*0.2
+  });
+});
+
+// ── calculateWatchMatchScore ──────────────────────────────────
+
+describe("calculateWatchMatchScore", () => {
+  it("スキルのみの条件で計算する", () => {
+    const score = calculateWatchMatchScore(
+      { skills: ["React", "TypeScript"], keywords: [] },
+      { skills: ["React", "TypeScript"], keywords: [] },
+    );
+    expect(score).toBe(1.0);
+  });
+
+  it("キーワードのみの条件で計算する", () => {
+    const score = calculateWatchMatchScore(
+      { skills: [], keywords: ["フロントエンド"] },
+      { skills: [], keywords: ["フロントエンド"] },
+    );
+    expect(score).toBe(1.0);
+  });
+
+  it("スキル+キーワードを均等に重み付けする", () => {
+    const score = calculateWatchMatchScore(
+      {
+        skills: ["React", "Vue"],
+        keywords: ["フロントエンド", "バックエンド"],
+      },
+      { skills: ["React"], keywords: ["フロントエンド"] },
+    );
+    // skillScore=0.5, keywordScore=0.5
+    // (0.5*0.5 + 0.5*0.5) / (0.5+0.5) = 0.5
+    expect(score).toBe(0.5);
+  });
+
+  it("条件がない場合はデフォルトで0.5を返す", () => {
+    const score = calculateWatchMatchScore(
+      { skills: [], keywords: [] },
+      { skills: ["React"], keywords: ["フロントエンド"] },
+    );
+    expect(score).toBe(0.5);
+  });
+
+  it("experienceLevelは無視される（ウォッチではスキルとキーワードのみ）", () => {
+    const score = calculateWatchMatchScore(
+      { skills: ["React"], keywords: [], experienceLevel: "SENIOR" },
+      { skills: ["React"], keywords: [] },
+    );
+    expect(score).toBe(1.0);
+  });
+});
+
+// ── extractSkillsAndKeywords ──────────────────────────────────
+
+describe("extractSkillsAndKeywords", () => {
+  it("フラグメントからスキルとキーワードを集約する", () => {
+    const result = extractSkillsAndKeywords([
+      { skills: ["React", "TypeScript"], keywords: ["フロントエンド"] },
+      { skills: ["Node.js"], keywords: ["バックエンド", "API"] },
+    ]);
+
+    expect(result.skills).toEqual(
+      expect.arrayContaining(["React", "TypeScript", "Node.js"]),
+    );
+    expect(result.skills).toHaveLength(3);
+    expect(result.keywords).toEqual(
+      expect.arrayContaining(["フロントエンド", "バックエンド", "API"]),
+    );
+    expect(result.keywords).toHaveLength(3);
+  });
+
+  it("重複するスキル・キーワードは除去される", () => {
+    const result = extractSkillsAndKeywords([
+      { skills: ["React", "TypeScript"], keywords: ["フロントエンド"] },
+      { skills: ["React", "Node.js"], keywords: ["フロントエンド", "API"] },
+    ]);
+
+    expect(result.skills).toHaveLength(3); // React重複除去
+    expect(result.keywords).toHaveLength(2); // フロントエンド重複除去
+  });
+
+  it("空のフラグメント配列では空のスキル・キーワードを返す", () => {
+    const result = extractSkillsAndKeywords([]);
+    expect(result.skills).toEqual([]);
+    expect(result.keywords).toEqual([]);
+  });
+
+  it("スキル・キーワードが空のフラグメントを処理できる", () => {
+    const result = extractSkillsAndKeywords([
+      { skills: [], keywords: [] },
+      { skills: ["React"], keywords: [] },
+    ]);
+    expect(result.skills).toEqual(["React"]);
+    expect(result.keywords).toEqual([]);
+  });
+});
+
+// ── テスト用ヘルパー ──────────────────────────────────
+
+function makeFragments(count: number, type = "FACT"): { type: string }[] {
+  return Array.from({ length: count }, () => ({ type }));
+}

--- a/src/lib/__tests__/verification.test.ts
+++ b/src/lib/__tests__/verification.test.ts
@@ -1,0 +1,326 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mocks ──────────────────────────────────────────────────────────
+
+const mockPrisma = {
+  emailVerificationToken: {
+    findFirst: vi.fn(),
+    findUnique: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    updateMany: vi.fn(),
+  },
+  account: {
+    update: vi.fn(),
+  },
+  $transaction: vi.fn(),
+};
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+const mockSendVerificationEmail = vi.fn();
+vi.mock("@/lib/email", () => ({
+  sendVerificationEmail: (...args: unknown[]) =>
+    mockSendVerificationEmail(...args),
+}));
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+const ACCOUNT_ID = "acc-001";
+const EMAIL = "test@example.com";
+
+function mockTokenRecord(overrides = {}) {
+  return {
+    id: "token-rec-001",
+    token: "abc123hex",
+    accountId: ACCOUNT_ID,
+    usedAt: null,
+    expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24時間後
+    createdAt: new Date(),
+    account: { id: ACCOUNT_ID, emailVerified: false },
+    ...overrides,
+  };
+}
+
+async function importModule() {
+  return import("@/lib/verification");
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+describe("verifyEmailToken", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("有効なトークンでメール認証が成功する", async () => {
+    const record = mockTokenRecord();
+    mockPrisma.emailVerificationToken.findUnique.mockResolvedValue(record);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mockTxClient: any = {
+      emailVerificationToken: {
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      account: {
+        update: vi.fn().mockResolvedValue({}),
+      },
+    };
+    mockPrisma.$transaction.mockImplementation(
+      async (callback: (tx: typeof mockTxClient) => Promise<unknown>) =>
+        callback(mockTxClient),
+    );
+
+    const { verifyEmailToken } = await importModule();
+    const result = await verifyEmailToken("abc123hex");
+
+    expect(result).toEqual({ success: true });
+  });
+
+  it("トランザクション内でusedAt: null条件付きupdateManyを実行する（TOCTOU防止）", async () => {
+    const record = mockTokenRecord();
+    mockPrisma.emailVerificationToken.findUnique.mockResolvedValue(record);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mockTxClient: any = {
+      emailVerificationToken: {
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      account: {
+        update: vi.fn().mockResolvedValue({}),
+      },
+    };
+    mockPrisma.$transaction.mockImplementation(
+      async (callback: (tx: typeof mockTxClient) => Promise<unknown>) =>
+        callback(mockTxClient),
+    );
+
+    const { verifyEmailToken } = await importModule();
+    await verifyEmailToken("abc123hex");
+
+    // usedAt: null 条件で原子的更新
+    expect(mockTxClient.emailVerificationToken.updateMany).toHaveBeenCalledWith(
+      {
+        where: { id: record.id, usedAt: null },
+        data: { usedAt: expect.any(Date) },
+      },
+    );
+
+    // アカウントのemailVerified更新
+    expect(mockTxClient.account.update).toHaveBeenCalledWith({
+      where: { id: ACCOUNT_ID },
+      data: { emailVerified: true },
+    });
+  });
+
+  it("同時リクエストで既にusedAtが設定された場合はエラーを返す（TOCTOU防止）", async () => {
+    const record = mockTokenRecord();
+    mockPrisma.emailVerificationToken.findUnique.mockResolvedValue(record);
+
+    // updateMany が count: 0 を返す = 別のリクエストが先に使用済みにした
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mockTxClient: any = {
+      emailVerificationToken: {
+        updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+      account: {
+        update: vi.fn(),
+      },
+    };
+    mockPrisma.$transaction.mockImplementation(
+      async (callback: (tx: typeof mockTxClient) => Promise<unknown>) =>
+        callback(mockTxClient),
+    );
+
+    const { verifyEmailToken } = await importModule();
+    await expect(verifyEmailToken("abc123hex")).rejects.toThrow(
+      "この認証リンクは既に使用されています",
+    );
+
+    // アカウント更新は実行されない
+    expect(mockTxClient.account.update).not.toHaveBeenCalled();
+  });
+
+  it("存在しないトークンでエラーを返す", async () => {
+    mockPrisma.emailVerificationToken.findUnique.mockResolvedValue(null);
+
+    const { verifyEmailToken } = await importModule();
+    await expect(verifyEmailToken("invalid")).rejects.toThrow(
+      "無効な認証リンクです",
+    );
+
+    expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("既に使用済みのトークンでエラーを返す", async () => {
+    const record = mockTokenRecord({ usedAt: new Date() });
+    mockPrisma.emailVerificationToken.findUnique.mockResolvedValue(record);
+
+    const { verifyEmailToken } = await importModule();
+    await expect(verifyEmailToken("abc123hex")).rejects.toThrow(
+      "この認証リンクは既に使用されています",
+    );
+
+    expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("有効期限切れのトークンでエラーを返す", async () => {
+    const record = mockTokenRecord({
+      expiresAt: new Date(Date.now() - 1000), // 1秒前に期限切れ
+    });
+    mockPrisma.emailVerificationToken.findUnique.mockResolvedValue(record);
+
+    const { verifyEmailToken } = await importModule();
+    await expect(verifyEmailToken("abc123hex")).rejects.toThrow(
+      "認証リンクの有効期限が切れています",
+    );
+
+    expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+  });
+});
+
+describe("createAndSendVerificationToken", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("トークンを作成してメールを送信する", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mockTxClient: any = {
+      emailVerificationToken: {
+        findFirst: vi.fn().mockResolvedValue(null),
+        create: vi.fn().mockResolvedValue({}),
+      },
+    };
+    mockPrisma.$transaction.mockImplementation(
+      async (callback: (tx: typeof mockTxClient) => Promise<unknown>) =>
+        callback(mockTxClient),
+    );
+    mockSendVerificationEmail.mockResolvedValue(undefined);
+
+    const { createAndSendVerificationToken } = await importModule();
+    await createAndSendVerificationToken(ACCOUNT_ID, EMAIL);
+
+    // トランザクション内でトークンが作成されている
+    expect(mockTxClient.emailVerificationToken.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        token: expect.any(String),
+        accountId: ACCOUNT_ID,
+        expiresAt: expect.any(Date),
+      }),
+    });
+
+    // メール送信が呼ばれている
+    expect(mockSendVerificationEmail).toHaveBeenCalledWith(
+      EMAIL,
+      expect.any(String),
+    );
+  });
+
+  it("クールダウンとトークン作成がトランザクション内で原子的に実行される（TOCTOU防止）", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mockTxClient: any = {
+      emailVerificationToken: {
+        findFirst: vi.fn().mockResolvedValue(null),
+        create: vi.fn().mockResolvedValue({}),
+      },
+    };
+    mockPrisma.$transaction.mockImplementation(
+      async (callback: (tx: typeof mockTxClient) => Promise<unknown>) =>
+        callback(mockTxClient),
+    );
+    mockSendVerificationEmail.mockResolvedValue(undefined);
+
+    const { createAndSendVerificationToken } = await importModule();
+    await createAndSendVerificationToken(ACCOUNT_ID, EMAIL);
+
+    // $transactionが呼ばれている（原子的実行）
+    expect(mockPrisma.$transaction).toHaveBeenCalledTimes(1);
+
+    // tx内でfindFirstが呼ばれている（トランザクション内でクールダウンチェック）
+    expect(mockTxClient.emailVerificationToken.findFirst).toHaveBeenCalledWith({
+      where: { accountId: ACCOUNT_ID },
+      orderBy: { createdAt: "desc" },
+    });
+  });
+
+  it("60秒以内に再送信するとエラーを返す", async () => {
+    const recentToken = {
+      createdAt: new Date(Date.now() - 30 * 1000), // 30秒前
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mockTxClient: any = {
+      emailVerificationToken: {
+        findFirst: vi.fn().mockResolvedValue(recentToken),
+        create: vi.fn(),
+      },
+    };
+    mockPrisma.$transaction.mockImplementation(
+      async (callback: (tx: typeof mockTxClient) => Promise<unknown>) =>
+        callback(mockTxClient),
+    );
+
+    const { createAndSendVerificationToken } = await importModule();
+    await expect(
+      createAndSendVerificationToken(ACCOUNT_ID, EMAIL),
+    ).rejects.toThrow(/秒後に可能です/);
+
+    // トークン作成もメール送信も実行されない
+    expect(mockTxClient.emailVerificationToken.create).not.toHaveBeenCalled();
+    expect(mockSendVerificationEmail).not.toHaveBeenCalled();
+  });
+
+  it("60秒経過後は再送信できる", async () => {
+    const oldToken = {
+      createdAt: new Date(Date.now() - 61 * 1000), // 61秒前
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mockTxClient: any = {
+      emailVerificationToken: {
+        findFirst: vi.fn().mockResolvedValue(oldToken),
+        create: vi.fn().mockResolvedValue({}),
+      },
+    };
+    mockPrisma.$transaction.mockImplementation(
+      async (callback: (tx: typeof mockTxClient) => Promise<unknown>) =>
+        callback(mockTxClient),
+    );
+    mockSendVerificationEmail.mockResolvedValue(undefined);
+
+    const { createAndSendVerificationToken } = await importModule();
+    await createAndSendVerificationToken(ACCOUNT_ID, EMAIL);
+
+    expect(mockTxClient.emailVerificationToken.create).toHaveBeenCalled();
+    expect(mockSendVerificationEmail).toHaveBeenCalled();
+  });
+
+  it("メール送信はトランザクション外で実行される", async () => {
+    let transactionCompleted = false;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mockTxClient: any = {
+      emailVerificationToken: {
+        findFirst: vi.fn().mockResolvedValue(null),
+        create: vi.fn().mockResolvedValue({}),
+      },
+    };
+    mockPrisma.$transaction.mockImplementation(
+      async (callback: (tx: typeof mockTxClient) => Promise<unknown>) => {
+        const result = await callback(mockTxClient);
+        transactionCompleted = true;
+        return result;
+      },
+    );
+    mockSendVerificationEmail.mockImplementation(() => {
+      // メール送信時点でトランザクションは完了しているはず
+      expect(transactionCompleted).toBe(true);
+      return Promise.resolve();
+    });
+
+    const { createAndSendVerificationToken } = await importModule();
+    await createAndSendVerificationToken(ACCOUNT_ID, EMAIL);
+
+    expect(mockSendVerificationEmail).toHaveBeenCalled();
+  });
+});

--- a/src/lib/api-utils.ts
+++ b/src/lib/api-utils.ts
@@ -169,6 +169,7 @@ export function withRecruiterAuth<T = unknown>(
   handler: RecruiterHandler<T>,
 ): (req: NextRequest, context?: T) => Promise<NextResponse> {
   return async (req: NextRequest, context?: T) => {
+    const start = performance.now();
     try {
       const session = await getServerSession(authOptions);
 
@@ -195,14 +196,27 @@ export function withRecruiterAuth<T = unknown>(
         throw new ForbiddenError("会社に所属していません");
       }
 
-      return await handler(
+      const response = await handler(
         req,
         session as unknown as AuthenticatedSession & {
           user: { recruiterId: string; companyId: string };
         },
         context as T,
       );
+      logger.info("api.response", {
+        method: req.method,
+        path: req.nextUrl.pathname,
+        status: response.status,
+        duration_ms: Math.round(performance.now() - start),
+      });
+      return response;
     } catch (error) {
+      logger.info("api.response", {
+        method: req.method,
+        path: req.nextUrl.pathname,
+        status: "error",
+        duration_ms: Math.round(performance.now() - start),
+      });
       return handleError(error, req?.nextUrl?.pathname);
     }
   };
@@ -236,6 +250,7 @@ export function withUserAuth<T = unknown>(
   handler: UserHandler<T>,
 ): (req: NextRequest, context?: T) => Promise<NextResponse> {
   return async (req: NextRequest, context?: T) => {
+    const start = performance.now();
     try {
       const session = await getServerSession(authOptions);
 
@@ -251,14 +266,27 @@ export function withUserAuth<T = unknown>(
         throw new ForbiddenError("ユーザー権限が必要です");
       }
 
-      return await handler(
+      const response = await handler(
         req,
         session as unknown as AuthenticatedSession & {
           user: { userId: string };
         },
         context as T,
       );
+      logger.info("api.response", {
+        method: req.method,
+        path: req.nextUrl.pathname,
+        status: response.status,
+        duration_ms: Math.round(performance.now() - start),
+      });
+      return response;
     } catch (error) {
+      logger.info("api.response", {
+        method: req.method,
+        path: req.nextUrl.pathname,
+        status: "error",
+        duration_ms: Math.round(performance.now() - start),
+      });
       return handleError(error, req?.nextUrl?.pathname);
     }
   };
@@ -294,6 +322,7 @@ export function withAuth<T = unknown>(
   options?: { skip2faCheck?: boolean },
 ): (req: NextRequest, context?: T) => Promise<NextResponse> {
   return async (req: NextRequest, context?: T) => {
+    const start = performance.now();
     try {
       const session = await getServerSession(authOptions);
 
@@ -312,12 +341,25 @@ export function withAuth<T = unknown>(
         throw new ForbiddenError("会社へのアクセス権が無効です");
       }
 
-      return await handler(
+      const response = await handler(
         req,
         session as unknown as AuthenticatedSession,
         context as T,
       );
+      logger.info("api.response", {
+        method: req.method,
+        path: req.nextUrl.pathname,
+        status: response.status,
+        duration_ms: Math.round(performance.now() - start),
+      });
+      return response;
     } catch (error) {
+      logger.info("api.response", {
+        method: req.method,
+        path: req.nextUrl.pathname,
+        status: "error",
+        duration_ms: Math.round(performance.now() - start),
+      });
       return handleError(error, req?.nextUrl?.pathname);
     }
   };
@@ -351,9 +393,23 @@ export function withErrorHandling<T = unknown>(
   handler: (req: NextRequest, context: T) => Promise<NextResponse>,
 ): (req: NextRequest, context?: T) => Promise<NextResponse> {
   return async (req: NextRequest, context?: T) => {
+    const start = performance.now();
     try {
-      return await handler(req, context as T);
+      const response = await handler(req, context as T);
+      logger.info("api.response", {
+        method: req.method,
+        path: req.nextUrl.pathname,
+        status: response.status,
+        duration_ms: Math.round(performance.now() - start),
+      });
+      return response;
     } catch (error) {
+      logger.info("api.response", {
+        method: req.method,
+        path: req.nextUrl.pathname,
+        status: "error",
+        duration_ms: Math.round(performance.now() - start),
+      });
       return handleError(error, req?.nextUrl?.pathname);
     }
   };

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -54,6 +54,10 @@ export const authOptions: NextAuthOptions = {
             return null;
           }
 
+          if (!account.emailVerified) {
+            throw new Error("EMAIL_NOT_VERIFIED");
+          }
+
           return {
             id: account.id,
             email: account.email,

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -23,6 +23,15 @@ async function populateTokenFromDb(token: JWT): Promise<void> {
   token.accountId = account.id;
   token.accountType = account.accountType;
   token.emailVerified = !!account.emailVerified;
+  // ロール変更時にstaleデータが残らないようリセット
+  token.userId = undefined;
+  token.userName = undefined;
+  token.avatarPath = undefined;
+  token.recruiterId = undefined;
+  token.companyId = undefined;
+  token.companyName = undefined;
+  token.companyRole = undefined;
+  token.recruiterStatus = undefined;
   if (account.user) {
     token.userId = account.user.id;
     token.userName = account.user.name;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -22,6 +22,7 @@ async function populateTokenFromDb(token: JWT): Promise<void> {
   if (!account) return;
   token.accountId = account.id;
   token.accountType = account.accountType;
+  token.emailVerified = !!account.emailVerified;
   if (account.user) {
     token.userId = account.user.id;
     token.userName = account.user.name;
@@ -85,15 +86,12 @@ export const authOptions: NextAuthOptions = {
             return null;
           }
 
-          if (!account.emailVerified) {
-            throw new Error("EMAIL_NOT_VERIFIED");
-          }
-
           return {
             id: account.id,
             email: account.email,
             name: account.user?.name || account.recruiter?.company?.name || "",
             accountType: account.accountType,
+            emailVerified: !!account.emailVerified,
           };
         }
 
@@ -124,21 +122,22 @@ export const authOptions: NextAuthOptions = {
           return null;
         }
 
-        if (!account.emailVerified) {
-          throw new Error("EMAIL_NOT_VERIFIED");
+        // パスキーが登録されていれば2FA検証を要求（メール認証済みの場合のみ）
+        let passkeyVerificationRequired = false;
+        if (account.emailVerified) {
+          const passkeyCount = await prisma.passkey.count({
+            where: { accountId: account.id },
+          });
+          passkeyVerificationRequired = passkeyCount > 0;
         }
-
-        // パスキーが登録されていれば2FA検証を要求
-        const passkeyCount = await prisma.passkey.count({
-          where: { accountId: account.id },
-        });
 
         return {
           id: account.id,
           email: account.email,
           name: account.user?.name || account.recruiter?.company?.name || "",
           accountType: account.accountType,
-          passkeyVerificationRequired: passkeyCount > 0,
+          emailVerified: !!account.emailVerified,
+          passkeyVerificationRequired,
         };
       },
     }),
@@ -149,6 +148,7 @@ export const authOptions: NextAuthOptions = {
       if (user && user.email) {
         token.email = user.email;
         token.accountType = user.accountType;
+        token.emailVerified = !!user.emailVerified;
         token.passkeyVerificationRequired =
           user.passkeyVerificationRequired ?? false;
         await populateTokenFromDb(token);
@@ -191,6 +191,7 @@ export const authOptions: NextAuthOptions = {
       if (session.user) {
         session.user.accountId = token.accountId;
         session.user.accountType = token.accountType;
+        session.user.emailVerified = token.emailVerified ?? false;
         session.user.passkeyVerificationRequired =
           token.passkeyVerificationRequired ?? false;
         if (token.userId) {

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -12,7 +12,10 @@ export async function sendVerificationEmail(
   to: string,
   token: string,
 ): Promise<void> {
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3001";
+  const appUrl =
+    process.env.NEXT_PUBLIC_APP_URL ||
+    process.env.NEXTAUTH_URL ||
+    "http://localhost:3001";
   const verifyUrl = `${appUrl}/verify-email?token=${token}`;
 
   // 開発環境: APIキーが未設定またはプレースホルダーの場合はコンソール出力のみ

--- a/src/lib/fragment-utils.ts
+++ b/src/lib/fragment-utils.ts
@@ -11,6 +11,17 @@ export const qualityToConfidence: Record<string, number> = {
 
 const FRAGMENT_TYPE_VALUES = new Set<string>(Object.values(FragmentType));
 
+export const fragmentTypeLabels: Record<string, string> = {
+  ACHIEVEMENT: "実績",
+  ACTION: "行動",
+  CHALLENGE: "課題",
+  LEARNING: "学び",
+  VALUE: "価値観",
+  EMOTION: "感情",
+  FACT: "事実",
+  SKILL_USAGE: "スキル活用",
+};
+
 /** 文字列を FragmentType に変換する。無効な値は "FACT" にフォールバック */
 export function parseFragmentType(value: string | undefined): FragmentType {
   if (value && FRAGMENT_TYPE_VALUES.has(value)) {

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -244,7 +244,8 @@ ${input.missingInfoHints.length > 0 ? input.missingInfoHints.join("\n") : "特�
     });
 
     return output ?? { questions: [], missingInfo: [], focusAreas: [] };
-  } catch {
+  } catch (error) {
+    logger.error("Interview guide generation failed", error as Error);
     return { questions: [], missingInfo: [], focusAreas: [] };
   }
 }
@@ -296,7 +297,8 @@ ${input.answer}`,
     });
 
     return output?.followUps ?? [];
-  } catch {
+  } catch (error) {
+    logger.error("Follow-up question generation failed", error as Error);
     return [];
   }
 }
@@ -426,7 +428,8 @@ ${conversationText}`,
     });
 
     return text;
-  } catch {
+  } catch (error) {
+    logger.error("Conversation summary generation failed", error as Error);
     return "";
   }
 }
@@ -471,7 +474,11 @@ export async function generateCandidateComparison(
     });
 
     return output ?? { summary: "分析結果を取得できませんでした" };
-  } catch {
+  } catch (error) {
+    logger.error(
+      "Candidate comparison structured output failed, falling back to text",
+      error as Error,
+    );
     try {
       const { text } = await generateText({
         model: defaultModel,
@@ -480,7 +487,11 @@ export async function generateCandidateComparison(
       });
 
       return { summary: text };
-    } catch {
+    } catch (fallbackError) {
+      logger.error(
+        "Candidate comparison fallback also failed",
+        fallbackError as Error,
+      );
       return { summary: "分析結果を取得できませんでした" };
     }
   }

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,13 +1,32 @@
 import { PrismaClient } from "@prisma/client";
+import { logger } from "@/lib/logger";
 
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined;
 };
 
-export const prisma =
-  globalForPrisma.prisma ??
-  new PrismaClient({
-    log: process.env.NODE_ENV === "development" ? ["query"] : [],
-  });
+function createPrismaClient(): PrismaClient {
+  if (process.env.NODE_ENV === "development") {
+    const client = new PrismaClient({
+      log: [
+        { level: "query", emit: "event" },
+        { level: "warn", emit: "stdout" },
+        { level: "error", emit: "stdout" },
+      ],
+    });
+    client.$on("query", (e) => {
+      if (e.duration > 50) {
+        logger.warn("prisma.slow_query", {
+          duration_ms: e.duration,
+          query: e.query.slice(0, 200),
+        });
+      }
+    });
+    return client;
+  }
+  return new PrismaClient();
+}
+
+export const prisma = globalForPrisma.prisma ?? createPrismaClient();
 
 if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;

--- a/src/lib/rate-limiter.ts
+++ b/src/lib/rate-limiter.ts
@@ -10,6 +10,10 @@ export type RateLimitPreset = {
 export const RATE_LIMIT_PRESETS = {
   /** 認証系公開エンドポイント: 10req/60s per IP */
   PUBLIC_AUTH: { points: 10, duration: 60 } satisfies RateLimitPreset,
+  /** アカウント登録: 5req/300s per IP（ブルートフォース防止） */
+  REGISTER: { points: 5, duration: 300 } satisfies RateLimitPreset,
+  /** メール認証・再送: 3req/300s per IP（スパム防止） */
+  VERIFY_EMAIL: { points: 3, duration: 300 } satisfies RateLimitPreset,
 } as const;
 
 const limiters = new Map<string, RateLimiterMemory>();

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,10 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export function getAvatarSrc(path: string): string {
+  if (path.startsWith("http://") || path.startsWith("https://")) {
+    return path;
+  }
+  return `/api/applicant/avatar/${path}`;
+}

--- a/src/lib/verification.ts
+++ b/src/lib/verification.ts
@@ -10,38 +10,47 @@ export async function createAndSendVerificationToken(
   accountId: string,
   email: string,
 ): Promise<void> {
-  // 60秒クールダウンチェック
-  const recentToken = await prisma.emailVerificationToken.findFirst({
-    where: { accountId },
-    orderBy: { createdAt: "desc" },
-  });
+  // トランザクション内でクールダウンチェック + トークン作成を原子的に実行
+  // （TOCTOU防止: 同時リクエストによるクールダウンバイパスを防ぐ）
+  const token = await prisma.$transaction(async (tx) => {
+    const recentToken = await tx.emailVerificationToken.findFirst({
+      where: { accountId },
+      orderBy: { createdAt: "desc" },
+    });
 
-  if (recentToken) {
-    const elapsed = (Date.now() - recentToken.createdAt.getTime()) / 1000;
-    if (elapsed < COOLDOWN_SECONDS) {
-      throw new ValidationError(
-        `再送信は${Math.ceil(COOLDOWN_SECONDS - elapsed)}秒後に可能です`,
-      );
+    if (recentToken) {
+      const elapsed = (Date.now() - recentToken.createdAt.getTime()) / 1000;
+      if (elapsed < COOLDOWN_SECONDS) {
+        throw new ValidationError(
+          `再送信は${Math.ceil(COOLDOWN_SECONDS - elapsed)}秒後に可能です`,
+        );
+      }
     }
-  }
 
-  const token = crypto.randomBytes(32).toString("hex");
-  const expiresAt = new Date(Date.now() + TOKEN_EXPIRY_HOURS * 60 * 60 * 1000);
+    const newToken = crypto.randomBytes(32).toString("hex");
+    const expiresAt = new Date(
+      Date.now() + TOKEN_EXPIRY_HOURS * 60 * 60 * 1000,
+    );
 
-  await prisma.emailVerificationToken.create({
-    data: {
-      token,
-      accountId,
-      expiresAt,
-    },
+    await tx.emailVerificationToken.create({
+      data: {
+        token: newToken,
+        accountId,
+        expiresAt,
+      },
+    });
+
+    return newToken;
   });
 
+  // メール送信はトランザクション外（外部副作用のため）
   await sendVerificationEmail(email, token);
 }
 
 export async function verifyEmailToken(
   token: string,
 ): Promise<{ success: true }> {
+  // 事前チェック（エラーメッセージの出し分け用、ここでは確定しない）
   const record = await prisma.emailVerificationToken.findUnique({
     where: { token },
     include: { account: true },
@@ -59,16 +68,24 @@ export async function verifyEmailToken(
     throw new ValidationError("認証リンクの有効期限が切れています");
   }
 
-  await prisma.$transaction([
-    prisma.account.update({
+  // TOCTOU防止: トランザクション内で usedAt: null 条件付き更新を原子的に実行
+  // 同時リクエストが両方 usedAt チェックを通過しても、
+  // updateMany の条件で1つだけが成功する
+  await prisma.$transaction(async (tx) => {
+    const updated = await tx.emailVerificationToken.updateMany({
+      where: { id: record.id, usedAt: null },
+      data: { usedAt: new Date() },
+    });
+
+    if (updated.count === 0) {
+      throw new ValidationError("この認証リンクは既に使用されています");
+    }
+
+    await tx.account.update({
       where: { id: record.accountId },
       data: { emailVerified: true },
-    }),
-    prisma.emailVerificationToken.update({
-      where: { id: record.id },
-      data: { usedAt: new Date() },
-    }),
-  ]);
+    });
+  });
 
   return { success: true };
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -34,6 +34,15 @@ declare module "next-auth/jwt" {
     email?: string;
     accountType?: AccountType;
     passkeyVerificationRequired?: boolean;
+    accountId?: string;
+    userId?: string;
+    userName?: string;
+    avatarPath?: string | null;
+    recruiterId?: string;
+    companyId?: string;
+    companyName?: string;
+    companyRole?: CompanyRole;
+    recruiterStatus?: CompanyMemberStatus;
   }
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,7 @@ declare module "next-auth" {
   interface User {
     accountType?: AccountType;
     passkeyVerificationRequired?: boolean;
+    emailVerified?: boolean;
   }
 
   interface Session {
@@ -25,6 +26,7 @@ declare module "next-auth" {
       companyRole?: CompanyRole;
       recruiterStatus?: CompanyMemberStatus;
       passkeyVerificationRequired?: boolean;
+      emailVerified?: boolean;
     };
   }
 }
@@ -34,6 +36,7 @@ declare module "next-auth/jwt" {
     email?: string;
     accountType?: AccountType;
     passkeyVerificationRequired?: boolean;
+    emailVerified?: boolean;
     accountId?: string;
     userId?: string;
     userName?: string;


### PR DESCRIPTION
## Summary
- feat: ドキュメントから抽出された記憶のかけらの確認機能を追加
- feat: チャットストリーム内に記憶のかけらカードを表示
- fix: チャットのエージェントアバターがpresigned URLで404になる問題を修正
- fix: FinishSuggestionの文言をより親しみやすい表現に変更
- refactor: アバターURL生成ロジックをgetAvatarSrcヘルパーに集約
- fix: 受信箱の公開ボタンをページ遷移からAPI直接呼び出しに変更
- feat: SystemPromptEditorのUI品質化
- test: APIルート・ライブラリのユニットテストを追加
- その他多数のバグ修正・セキュリティ強化・パフォーマンス改善

## Test plan
- [x] `npx tsc --noEmit` 型チェック通過
- [x] `npm run check` Biome lint通過
- [x] `npm run test:run` 全44ファイル / 768テスト通過